### PR TITLE
Added support for deleteObject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@
 *.tar.gz
 *.rar
 
+# IDE Files #
+*.iml
+.idea/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
@@ -15,6 +15,7 @@
  */
 package com.evolveum.midpoint.client.api;
 
+import com.evolveum.midpoint.client.api.verb.Delete;
 import com.evolveum.midpoint.client.api.verb.Get;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
@@ -22,6 +23,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
  * @author semancik
  *
  */
-public interface ObjectService<O extends ObjectType> extends Get<O> {
+public interface ObjectService<O extends ObjectType> extends Get<O>, Delete<O>
+{
 
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/verb/Delete.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/verb/Delete.java
@@ -15,12 +15,16 @@
  */
 package com.evolveum.midpoint.client.api.verb;
 
+import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+
 /**
  * @author semancik
  *
  */
 public interface Delete<T> {
 
-	T delete();
+	//TODO: Does this need to return anything?
+	void delete() throws ObjectNotFoundException, AuthenticationException;;
 	
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/verb/Post.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/verb/Post.java
@@ -18,10 +18,7 @@ package com.evolveum.midpoint.client.api.verb;
 import java.util.concurrent.ExecutionException;
 
 import com.evolveum.midpoint.client.api.TaskFuture;
-import com.evolveum.midpoint.client.api.exception.AuthorizationException;
-import com.evolveum.midpoint.client.api.exception.CommonException;
-import com.evolveum.midpoint.client.api.exception.OperationInProgressException;
-import com.evolveum.midpoint.client.api.exception.SystemException;
+import com.evolveum.midpoint.client.api.exception.*;
 
 /**
  * @author semancik
@@ -67,6 +64,6 @@ public interface Post<T> {
 	 * Potentially asynchronous POST.
 	 * @throws AuthorizationException 
 	 */
-	TaskFuture<T> apost() throws AuthorizationException;
+	TaskFuture<T> apost() throws AuthorizationException, ObjectAlreadyExistsException;
 	
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/AuthenticationType.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/AuthenticationType.java
@@ -18,7 +18,7 @@ package com.evolveum.midpoint.client.impl.restjaxb;
 import java.util.Arrays;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jetty.server.Authentication;
+
 
 import com.evolveum.midpoint.client.api.exception.SchemaException;
 

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectAddService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectAddService.java
@@ -15,12 +15,14 @@
  */
 package com.evolveum.midpoint.client.impl.restjaxb;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 
 import com.evolveum.midpoint.client.api.ObjectAddService;
 import com.evolveum.midpoint.client.api.ObjectReference;
 import com.evolveum.midpoint.client.api.TaskFuture;
 import com.evolveum.midpoint.client.api.exception.AuthorizationException;
+import com.evolveum.midpoint.client.api.exception.ObjectAlreadyExistsException;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
 /**
@@ -38,7 +40,7 @@ public class RestJaxbObjectAddService<O extends ObjectType> extends AbstractObje
 	}
 
 	@Override
-	public TaskFuture<ObjectReference<O>> apost() throws AuthorizationException {
+	public TaskFuture<ObjectReference<O>> apost() throws AuthorizationException, ObjectAlreadyExistsException {
 		// TODO: add object
 		
 		// if object created (sync):
@@ -47,10 +49,15 @@ public class RestJaxbObjectAddService<O extends ObjectType> extends AbstractObje
 		Response response = getService().getClient().replacePath("/" + restPath).post(object);
 		
 		switch (response.getStatus()) {
+			case 400:
+				throw new BadRequestException(response.getStatusInfo().getReasonPhrase());
 			case 401:
 			case 403:
 				throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
+			case 409:
+				throw new ObjectAlreadyExistsException(response.getStatusInfo().getReasonPhrase());
 			case 202:
+			case 201:
 				String location = response.getLocation().toString();
 				String[] locationSegments = location.split(restPath + "/");
 				oid = locationSegments[1];
@@ -59,8 +66,8 @@ public class RestJaxbObjectAddService<O extends ObjectType> extends AbstractObje
 		default:
 			throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
 		}
-				
+
 	}
-	
+
 	
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectAddService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectAddService.java
@@ -56,8 +56,8 @@ public class RestJaxbObjectAddService<O extends ObjectType> extends AbstractObje
 				throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
 			case 409:
 				throw new ObjectAlreadyExistsException(response.getStatusInfo().getReasonPhrase());
-			case 202:
 			case 201:
+			case 202:
 				String location = response.getLocation().toString();
 				String[] locationSegments = location.split(restPath + "/");
 				oid = locationSegments[1];

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -34,6 +34,11 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	public O get() throws ObjectNotFoundException, AuthenticationException {
 		return getService().getObject(getType(), getOid());
 	}
-	
-	
+
+
+	@Override
+	public void delete() throws ObjectNotFoundException, AuthenticationException
+	{
+		 getService().deleteObject(getType(), getOid());
+	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -164,6 +164,23 @@ public class RestJaxbService implements Service {
 		return null;
 	}
 
+	<O extends ObjectType> void deleteObject(final Class<O> type, final String oid) throws ObjectNotFoundException, AuthenticationException {
+		String urlPrefix = RestUtil.subUrl(Types.findType(type).getRestPath(), oid);
+		Response response = client.replacePath(urlPrefix).delete();
+
+		if (Status.OK.getStatusCode() == response.getStatus() ) {
+			//TODO: Do we want to return anything on successful delete or just remove this if block?
+		}
+
+		if (Status.NOT_FOUND.getStatusCode() == response.getStatus()) {
+			throw new ObjectNotFoundException("Cannot delete object with oid" + oid + ". Object doesn't exist");
+		}
+
+		if (Status.UNAUTHORIZED.getStatusCode() == response.getStatus()) {
+			throw new AuthenticationException("Cannot authentication user");
+		}
+	}
+
 	private JAXBContext createJaxbContext() throws JAXBException {
 		JAXBContext jaxbCtx = JAXBContext.newInstance("com.evolveum.midpoint.xml.ns._public.common.api_types_3:"
 				+ "com.evolveum.midpoint.xml.ns._public.common.audit_3:"

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -159,7 +159,7 @@ public class RestJaxbService implements Service {
 		}
 		
 		if (Status.UNAUTHORIZED.getStatusCode() == response.getStatus()) {
-			throw new AuthenticationException();
+			throw new AuthenticationException(response.getStatusInfo().getReasonPhrase());
 		}
 		
 		return null;

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -158,7 +159,7 @@ public class RestJaxbService implements Service {
 		}
 		
 		if (Status.UNAUTHORIZED.getStatusCode() == response.getStatus()) {
-			throw new AuthenticationException("Cannot authentication user");
+			throw new AuthenticationException();
 		}
 		
 		return null;
@@ -168,8 +169,18 @@ public class RestJaxbService implements Service {
 		String urlPrefix = RestUtil.subUrl(Types.findType(type).getRestPath(), oid);
 		Response response = client.replacePath(urlPrefix).delete();
 
+		//TODO: Looks like midPoint returns a 204 and not a 200 on success
 		if (Status.OK.getStatusCode() == response.getStatus() ) {
 			//TODO: Do we want to return anything on successful delete or just remove this if block?
+		}
+
+		if (Status.NO_CONTENT.getStatusCode() == response.getStatus() ) {
+			//TODO: Do we want to return anything on successful delete or just remove this if block?
+		}
+
+
+		if (Status.BAD_REQUEST.getStatusCode() == response.getStatus()) {
+			throw new BadRequestException("Bad request");
 		}
 
 		if (Status.NOT_FOUND.getStatusCode() == response.getStatus()) {

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -107,6 +107,38 @@ public class TestBasic {
 		}
 		
 	}
+
+	@Test
+	public void test004UserDeleteNotExist() throws Exception{
+		Service service = getService();
+
+		// WHEN
+		try{
+			service.users().oid("999").delete();
+			fail("Unexpected user deleted");
+		}catch(ObjectNotFoundException e){
+			// nothing to do. this is expected
+		}
+	}
+
+	@Test
+	public void test005UserDelete() throws Exception{
+		// SETUP
+		Service service = getService();
+
+		UserType userDelete = new UserType();
+		userDelete.setOid("321");
+
+		ObjectReference<UserType> ref = service.users().add(userDelete).post();
+		assertNotNull("Setup failed, user not added", ref.getOid());
+
+		// WHEN
+		try{
+			service.users().oid("321").delete();
+		}catch(ObjectNotFoundException e){
+			fail("Cannot delete user, user not found");
+		}
+	}
 	
 	@Test
 	public void test010UserSearch() throws Exception {

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -55,11 +55,12 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 public class TestBasic {
 	
 	private static Server server;
-	private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
-	
+	//private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
+	private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
+
 	@BeforeClass
 	public void init() throws IOException {
-		startServer();
+		//startServer();
 	}
 	
 	@Test
@@ -122,19 +123,13 @@ public class TestBasic {
 	}
 
 	@Test
-	public void test005UserDelete() throws Exception{
+	public void test201UserDelete() throws Exception{
 		// SETUP
 		Service service = getService();
 
-		UserType userDelete = new UserType();
-		userDelete.setOid("321");
-
-		ObjectReference<UserType> ref = service.users().add(userDelete).post();
-		assertNotNull("Setup failed, user not added", ref.getOid());
-
 		// WHEN
 		try{
-			service.users().oid("321").delete();
+			service.users().oid("123").delete();
 		}catch(ObjectNotFoundException e){
 			fail("Cannot delete user, user not found");
 		}

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -55,12 +55,11 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 public class TestBasic {
 	
 	private static Server server;
-	//private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
-	private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
+	private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
 
 	@BeforeClass
 	public void init() throws IOException {
-		//startServer();
+		startServer();
 	}
 	
 	@Test
@@ -179,9 +178,8 @@ public class TestBasic {
 			} else {
 				qa.setQans("I do NOT have FAVORITE c0l0r!");
 			}
-			
+
 		}
-		
 		
 		service = (RestJaxbService) getService("administrator", challenge.getAnswer());
 		

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
@@ -22,13 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -106,6 +100,29 @@ public class MidpointMockRestService {
 		
 		return Response.status(Status.OK).header("Content-Type", MediaType.APPLICATION_XML).entity(objectType).build();
 		
+	}
+
+	@DELETE
+	@Path("/{type}/{id}")
+	@Produces({MediaType.APPLICATION_XML})
+	public <T extends ObjectType> Response deleteObject(@PathParam("type") String type, @PathParam("id") String id,
+                                                        @QueryParam("options") List<String> options,
+                                                        @QueryParam("include") List<String> include,
+                                                        @QueryParam("exclude") List<String> exclude,
+                                                        @Context MessageContext mc){
+
+		OperationResultType result = new OperationResultType();
+		result.setOperation("Get object");
+		objectMap.get(type).remove(id);
+
+		if (objectMap.get(type).containsKey(id)) {
+			result.setStatus(OperationResultStatusType.FATAL_ERROR);
+			result.setMessage("User with oid " + id + " was not deleted");
+			return RestMockServiceUtil.createResponse(Status.FOUND, result);
+		}
+
+		return Response.status(Status.OK).header("Content-Type", MediaType.APPLICATION_XML).build();
+
 	}
 	
 	@POST

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
@@ -112,17 +112,17 @@ public class MidpointMockRestService {
                                                         @Context MessageContext mc){
 
 		OperationResultType result = new OperationResultType();
-		result.setOperation("Get object");
+		result.setOperation("Delete object");
+
+        if (!objectMap.get(type).containsKey(id)) {
+            result.setStatus(OperationResultStatusType.FATAL_ERROR);
+            result.setMessage("Object with oid " + id + " was not found.");
+            return RestMockServiceUtil.createResponse(Status.NOT_FOUND, result);
+        }
+
 		objectMap.get(type).remove(id);
 
-		if (objectMap.get(type).containsKey(id)) {
-			result.setStatus(OperationResultStatusType.FATAL_ERROR);
-			result.setMessage("User with oid " + id + " was not deleted");
-			return RestMockServiceUtil.createResponse(Status.FOUND, result);
-		}
-
 		return Response.status(Status.OK).header("Content-Type", MediaType.APPLICATION_XML).build();
-
 	}
 	
 	@POST


### PR DESCRIPTION
I decided to try implementing deleteObject first to get used to the code base and design. 
I also added some additional support for http responses as some of the tests were breaking when run against our actual midPoint deployment. 

I added two test cases a mock API endpoint. Hopefully these were done in a way that makes sense. 