### PR TITLE
Added modifyObjectPost

### DIFF
--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -9,4 +9,6 @@ import java.util.Map;
  * @author jakmor
  */
 public interface ObjectModifyService <O extends ObjectType> extends Post<ObjectReference<O>>{
+
+    ObjectModifyService<O> add(String path, Object value);
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -1,0 +1,12 @@
+package com.evolveum.midpoint.client.api;
+
+/**
+ * Description
+ *
+ * @author Jake Morris - jake
+ * @version 1.0
+ * @since 1.0
+ */
+public class ObjectModifyService
+{
+}

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -10,5 +10,5 @@ import java.util.Map;
  */
 public interface ObjectModifyService <O extends ObjectType> extends Post<ObjectReference<O>>{
 
-    ObjectModifyService<O> add(String path, Object value);
+    ObjectModifyService<O> item(String path, Object value);
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -3,6 +3,8 @@ package com.evolveum.midpoint.client.api;
 import com.evolveum.midpoint.client.api.verb.Post;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
+import java.util.Map;
+
 /**
  * @author jakmor
  */

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -1,12 +1,10 @@
 package com.evolveum.midpoint.client.api;
 
+import com.evolveum.midpoint.client.api.verb.Post;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
 /**
- * Description
- *
- * @author Jake Morris - jake
- * @version 1.0
- * @since 1.0
+ * @author jakmor
  */
-public class ObjectModifyService
-{
+public interface ObjectModifyService <O extends ObjectType> extends Post<ObjectReference<O>>{
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
@@ -15,9 +15,13 @@
  */
 package com.evolveum.midpoint.client.api;
 
+import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.client.api.verb.Delete;
 import com.evolveum.midpoint.client.api.verb.Get;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
+import java.util.Map;
 
 /**
  * @author semancik
@@ -25,5 +29,5 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
  */
 public interface ObjectService<O extends ObjectType> extends Get<O>, Delete<O>
 {
-
+    ObjectModifyService<O> modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
@@ -30,4 +30,5 @@ import java.util.Map;
 public interface ObjectService<O extends ObjectType> extends Get<O>, Delete<O>
 {
     ObjectModifyService<O> modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException;
+    ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/verb/Post.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/verb/Post.java
@@ -64,6 +64,6 @@ public interface Post<T> {
 	 * Potentially asynchronous POST.
 	 * @throws AuthorizationException 
 	 */
-	TaskFuture<T> apost() throws AuthorizationException, ObjectAlreadyExistsException;
+	TaskFuture<T> apost() throws CommonException;
 	
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectAddService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectAddService.java
@@ -41,7 +41,7 @@ public class RestJaxbObjectAddService<O extends ObjectType> extends AbstractObje
 
 	@Override
 	public TaskFuture<ObjectReference<O>> apost() throws AuthorizationException, ObjectAlreadyExistsException {
-		// TODO: add object
+		// TODO: item object
 		
 		// if object created (sync):
 		String oid = null;

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -1,12 +1,56 @@
 package com.evolveum.midpoint.client.impl.restjaxb;
 
+import com.evolveum.midpoint.client.api.ObjectModifyService;
+import com.evolveum.midpoint.client.api.TaskFuture;
+import com.evolveum.midpoint.client.api.exception.AuthorizationException;
+import com.evolveum.midpoint.client.api.exception.CommonException;
+import com.evolveum.midpoint.client.api.exception.ObjectAlreadyExistsException;
+import com.evolveum.midpoint.client.api.exception.OperationInProgressException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
 /**
  * Description
- *
- * @author Jake Morris - jake
- * @version 1.0
- * @since 1.0
+ * @author jakmor
  */
-public class RestJaxbObjectModifyService
+public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractObjectTypeWebResource<O> implements ObjectModifyService
 {
+
+    private Map<String, Object> modifications;
+
+    public RestJaxbObjectModifyService(RestJaxbService service, Class<O> type)
+    {
+        super(service, type);
+    }
+
+    @Override
+    public TaskFuture apost() throws AuthorizationException, ObjectAlreadyExistsException
+    {
+        // if object created (sync):
+        String oid = null;
+        String restPath = Types.findType(getType()).getRestPath();
+        Response response = getService().getClient().replacePath("/" + restPath).post();
+
+        switch (response.getStatus()) {
+            case 400:
+                throw new BadRequestException(response.getStatusInfo().getReasonPhrase());
+            case 401:
+            case 403:
+                throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
+            case 409:
+                throw new ObjectAlreadyExistsException(response.getStatusInfo().getReasonPhrase());
+            case 201:
+            case 202:
+                String location = response.getLocation().toString();
+                String[] locationSegments = location.split(restPath + "/");
+                oid = locationSegments[1];
+                RestJaxbObjectReference<O> ref = new RestJaxbObjectReference<>(getService(), getType(), oid);
+                return new RestJaxbCompletedFuture<>(ref);
+            default:
+                throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
+        }
+    }
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -14,7 +14,6 @@ import javax.ws.rs.core.Response;
 import java.util.Map;
 
 /**
- * Description
  * @author jakmor
  */
 public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractObjectWebResource<O> implements ObjectModifyService<O>
@@ -44,8 +43,8 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
                 throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
             case 409:
                 throw new ObjectAlreadyExistsException(response.getStatusInfo().getReasonPhrase());
-            case 201:
-            case 202:
+                //TODO: Do we want to return a reference? Might be useful.
+            case 204:
                 RestJaxbObjectReference<O> ref = new RestJaxbObjectReference<>(getService(), getType(), oid);
                 return new RestJaxbCompletedFuture<>(ref);
             default:

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -22,7 +22,7 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
     public RestJaxbObjectModifyService(RestJaxbService service, Class<O> type, String oid)
     {
 
-        this(service, type, oid, new HashMap<String, Object>());
+        this(service, type, oid, new HashMap<>());
     }
 
 
@@ -32,6 +32,7 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
         this.modifications = modifications;
     }
 
+    @Override
     public RestJaxbObjectModifyService<O> item(String path, Object value){
         this.modifications.put(path, value);
         return this;

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -1,0 +1,12 @@
+package com.evolveum.midpoint.client.impl.restjaxb;
+
+/**
+ * Description
+ *
+ * @author Jake Morris - jake
+ * @version 1.0
+ * @since 1.0
+ */
+public class RestJaxbObjectModifyService
+{
+}

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * Description
  * @author jakmor
  */
-public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractObjectWebResource<O> implements ObjectModifyService
+public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractObjectWebResource<O> implements ObjectModifyService<O>
 {
 
     private Map<String, Object> modifications;
@@ -31,11 +31,10 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
     @Override
     public TaskFuture apost() throws AuthorizationException, ObjectAlreadyExistsException
     {
-        // if object created (sync):
         String oid = getOid();
-        String restPath = Types.findType(getType()).getRestPath();
+        String restPath = RestUtil.subUrl(Types.findType(getType()).getRestPath(), oid);
 
-        Response response = getService().getClient().replacePath("/" + restPath + "/" + oid).post(RestUtil.buildModifyObject(modifications, ModificationTypeType.REPLACE));
+        Response response = getService().getClient().replacePath(restPath).post(RestUtil.buildModifyObject(modifications, ModificationTypeType.ADD));
 
         switch (response.getStatus()) {
             case 400:

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -11,6 +11,7 @@ import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -21,10 +22,22 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
 
     private Map<String, Object> modifications;
 
+    public RestJaxbObjectModifyService(RestJaxbService service, Class<O> type, String oid)
+    {
+
+        this(service, type, oid, new HashMap<String, Object>());
+    }
+
+
     public RestJaxbObjectModifyService(RestJaxbService service, Class<O> type, String oid, Map<String, Object> modifications)
     {
         super(service, type, oid);
         this.modifications = modifications;
+    }
+
+    public RestJaxbObjectModifyService<O> add(String path, Object value){
+        modifications.put(path, value);
+        return this;
     }
 
     @Override

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -2,10 +2,7 @@ package com.evolveum.midpoint.client.impl.restjaxb;
 
 import com.evolveum.midpoint.client.api.ObjectModifyService;
 import com.evolveum.midpoint.client.api.TaskFuture;
-import com.evolveum.midpoint.client.api.exception.AuthorizationException;
-import com.evolveum.midpoint.client.api.exception.CommonException;
-import com.evolveum.midpoint.client.api.exception.ObjectAlreadyExistsException;
-import com.evolveum.midpoint.client.api.exception.OperationInProgressException;
+import com.evolveum.midpoint.client.api.exception.*;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
 
@@ -41,7 +38,7 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
     }
 
     @Override
-    public TaskFuture apost() throws AuthorizationException, ObjectAlreadyExistsException
+    public TaskFuture apost() throws AuthorizationException, ObjectNotFoundException
     {
         String oid = getOid();
         String restPath = RestUtil.subUrl(Types.findType(getType()).getRestPath(), oid);
@@ -54,9 +51,9 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
             case 401:
             case 403:
                 throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
-            case 409:
-                throw new ObjectAlreadyExistsException(response.getStatusInfo().getReasonPhrase());
                 //TODO: Do we want to return a reference? Might be useful.
+            case 404:
+                throw new ObjectNotFoundException(response.getStatusInfo().getReasonPhrase());
             case 204:
                 RestJaxbObjectReference<O> ref = new RestJaxbObjectReference<>(getService(), getType(), oid);
                 return new RestJaxbCompletedFuture<>(ref);

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -51,6 +51,7 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid(), modifications);
 	}
 
+	@Override
 	public ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException
 	{
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid());

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -15,6 +15,7 @@
  */
 package com.evolveum.midpoint.client.impl.restjaxb;
 
+import com.evolveum.midpoint.client.api.ObjectModifyService;
 import com.evolveum.midpoint.client.api.ObjectService;
 import com.evolveum.midpoint.client.api.exception.AuthenticationException;
 import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
@@ -45,8 +46,8 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	}
 
 	@Override
-	public void modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException
+	public ObjectModifyService<O> modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException
 	{
-		return new RestJaxbObjectModifyService<O>(getService(), getType(), getOid(), modifications);
+		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid(), modifications);
 	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -20,6 +20,8 @@ import com.evolveum.midpoint.client.api.exception.AuthenticationException;
 import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
+import java.util.Map;
+
 /**
  * @author semancik
  *
@@ -40,5 +42,10 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	public void delete() throws ObjectNotFoundException, AuthenticationException
 	{
 		 getService().deleteObject(getType(), getOid());
+	}
+
+	public void modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException
+	{
+		getService().modifyObject(getType(), getOid(), modifications);
 	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -44,8 +44,9 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 		 getService().deleteObject(getType(), getOid());
 	}
 
+	@Override
 	public void modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException
 	{
-		getService().modifyObject(getType(), getOid(), modifications);
+		return new RestJaxbObjectModifyService<O>(getService(), getType(), getOid(), modifications);
 	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -50,4 +50,9 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	{
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid(), modifications);
 	}
+
+	public ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException
+	{
+		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid());
+	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -193,10 +193,6 @@ public class RestJaxbService implements Service {
 		}
 	}
 
-	<O extends ObjectType> void modifyObject(final Class<O> type, final String oid, Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException {
-		
-	}
-
 	private JAXBContext createJaxbContext() throws JAXBException {
 		JAXBContext jaxbCtx = JAXBContext.newInstance("com.evolveum.midpoint.xml.ns._public.common.api_types_3:"
 				+ "com.evolveum.midpoint.xml.ns._public.common.audit_3:"

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MediaType;
@@ -190,6 +191,10 @@ public class RestJaxbService implements Service {
 		if (Status.UNAUTHORIZED.getStatusCode() == response.getStatus()) {
 			throw new AuthenticationException("Cannot authentication user");
 		}
+	}
+
+	<O extends ObjectType> void modifyObject(final Class<O> type, final String oid, Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException {
+		
 	}
 
 	private JAXBContext createJaxbContext() throws JAXBException {

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbServiceUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbServiceUtil.java
@@ -61,5 +61,4 @@ public class RestJaxbServiceUtil implements ServiceUtil {
 		Arrays.asList(qname).forEach(name -> itemPathType.setValue(itemPathType + "/" + name.getLocalPart()));
 		return itemPathType;
 	}
-
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbServiceUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbServiceUtil.java
@@ -16,11 +16,15 @@
 package com.evolveum.midpoint.client.impl.restjaxb;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import javax.xml.namespace.QName;
 
 import com.evolveum.midpoint.client.api.ServiceUtil;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
+import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
+import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
 import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
 
 /**

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
@@ -15,6 +15,13 @@
  */
 package com.evolveum.midpoint.client.impl.restjaxb;
 
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
+import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
+import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
+import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
+
+import java.util.Map;
+
 /**
  * @author semancik
  *
@@ -24,6 +31,46 @@ public class RestUtil {
 	public static String subUrl(final String urlPrefix, final String pathSegment) {
 		// TODO: better code (e.g. escaping)
 		return "/" + urlPrefix + "/" + pathSegment;
+	}
+
+	//TODO: If these work, add to interface
+	public static ObjectModificationType buildModifyObject(String path, Object value, ModificationTypeType modificationType)
+	{
+		ObjectModificationType objectModificationType = new ObjectModificationType();
+		objectModificationType.getItemDelta().add(buildItemDelta(modificationType, path, value));
+		return objectModificationType;
+	}
+
+	public static ObjectModificationType buildModifyObject(Map<String, Object> pathValueMap, ModificationTypeType modificationType)
+	{
+		ObjectModificationType objectModificationType = new ObjectModificationType();
+		pathValueMap.forEach((path, value) ->
+				objectModificationType.getItemDelta().add(buildItemDelta(modificationType, path, value)));
+
+		return objectModificationType;
+	}
+
+	public static ItemDeltaType buildItemDelta(ModificationTypeType modificationType, String path, Object value)
+	{
+		//Create ItemDelta
+		ItemDeltaType itemDeltaType = new ItemDeltaType();
+		itemDeltaType.setModificationType(modificationType);
+
+		//Set Path
+		ItemPathType itemPathType = new ItemPathType();
+		itemPathType.setValue(path);
+		itemDeltaType.setPath(itemPathType);
+
+		//Set Value
+		//TODO: Refactor. This really sucks. Passing an Object is very open-ended here.
+		//This is done because currently when a string value is marshalled to xml it gets a type attribute
+		//on it. That type attribute can cause conflicts depending on the attribute being updated.
+		//For example, if updating GivenName, an error would be thrown as midpoint is expecting a polyStringType.
+		//This is probably a namespacing issue. The current marshalling process is not robust enough to handle it and
+		//still be generic.
+		itemDeltaType.getValue().add(value);
+
+		return itemDeltaType;
 	}
 	
 

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
@@ -33,7 +33,7 @@ public class RestUtil {
 		return "/" + urlPrefix + "/" + pathSegment;
 	}
 
-	//TODO: If these work, add to interface
+	//TODO: If these work, item to interface
 	public static ObjectModificationType buildModifyObject(String path, Object value, ModificationTypeType modificationType)
 	{
 		ObjectModificationType objectModificationType = new ObjectModificationType();

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/Types.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/Types.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import javax.xml.namespace.QName;
 
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectListType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
 import com.evolveum.prism.xml.ns._public.query_3.QueryType;
@@ -33,8 +34,9 @@ public enum Types {
 
 	USERS(UserType.class, new QName(SchemaConstants.NS_COMMON, "user"), "users"),
 	QUERY(QueryType.class, new QName(SchemaConstants.NS_QUERY, "query"), null),
-	OBJECT_LIST_TYPPE(ObjectListType.class, new QName(SchemaConstants.NS_API_TYPES, "objectList"), ""),
-	POLICY_ITEMS_DEFINITION(PolicyItemsDefinitionType.class, new QName(SchemaConstants.NS_API_TYPES, "policyItemsDefinition"), "");
+	OBJECT_LIST_TYPE(ObjectListType.class, new QName(SchemaConstants.NS_API_TYPES, "objectList"), ""),
+	POLICY_ITEMS_DEFINITION(PolicyItemsDefinitionType.class, new QName(SchemaConstants.NS_API_TYPES, "policyItemsDefinition"), ""),
+	OBJECT_MODIFICATION_TYPE(ObjectModificationType.class, new QName(SchemaConstants.NS_API_TYPES, "objectModification"), "");
 	
 	
 	

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -139,6 +139,16 @@ public class TestBasic {
 		}catch(Exception e){
 			fail("Modification failed: " + e.getMessage());
 		}
+
+		try{
+			//TODO: service.users().oid("123").modify();
+			service.users().oid("123").modify()
+					.add("givenName", service.util().createPoly("Example given name"))
+					.add("lastName", service.util().createPoly("Example last name"))
+					.apost();
+		}catch(Exception e){
+			fail("Modification failed: " + e.getMessage());
+		}
 	}
 
 	@Test

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -21,7 +21,9 @@ import static org.testng.AssertJUnit.assertNotNull;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -55,11 +57,12 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 public class TestBasic {
 	
 	private static Server server;
-	private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
+	//private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
+	private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
 
 	@BeforeClass
 	public void init() throws IOException {
-		startServer();
+		//startServer();
 	}
 	
 	@Test
@@ -125,25 +128,30 @@ public class TestBasic {
 	public void test005UserModify() throws Exception{
 		Service service = getService();
 
+		Map<String, Object> modifications = new HashMap<>();
+
+		modifications.put("description", "test description");
+
 		// WHEN
 		try{
 			//TODO: service.users().oid("123").modify();
+			service.users().oid("123").modify(modifications).apost();
 		}catch(Exception e){
-
+			fail("Modification failed: " + e.getMessage());
 		}
 	}
 
 	@Test
 	public void test201UserDelete() throws Exception{
 		// SETUP
-		Service service = getService();
+	/*	Service service = getService();
 
 		// WHEN
 		try{
 			service.users().oid("123").delete();
 		}catch(ObjectNotFoundException e){
 			fail("Cannot delete user, user not found");
-		}
+		}*/
 	}
 	
 	@Test

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -129,24 +129,21 @@ public class TestBasic {
 		Service service = getService();
 
 		Map<String, Object> modifications = new HashMap<>();
-
 		modifications.put("description", "test description");
 
 		// WHEN
 		try{
-			//TODO: service.users().oid("123").modify();
 			service.users().oid("123").modify(modifications).apost();
-		}catch(Exception e){
-			fail("Modification failed: " + e.getMessage());
+		}catch(ObjectNotFoundException e){
+			fail("Bulk modification failed: " + e.getMessage());
 		}
 
 		try{
-			//TODO: service.users().oid("123").modify();
 			service.users().oid("123").modify()
 					.add("givenName", service.util().createPoly("Example given name"))
 					.add("lastName", service.util().createPoly("Example last name"))
 					.apost();
-		}catch(Exception e){
+		}catch(ObjectNotFoundException e){
 			fail("Modification failed: " + e.getMessage());
 		}
 	}

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -122,6 +122,18 @@ public class TestBasic {
 	}
 
 	@Test
+	public void test005UserModify() throws Exception{
+		Service service = getService();
+
+		// WHEN
+		try{
+			//TODO: service.users().oid("123").modify();
+		}catch(Exception e){
+
+		}
+	}
+
+	@Test
 	public void test201UserDelete() throws Exception{
 		// SETUP
 		Service service = getService();

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -128,37 +128,35 @@ public class TestBasic {
 	public void test005UserModify() throws Exception{
 		Service service = getService();
 
+
 		Map<String, Object> modifications = new HashMap<>();
 		modifications.put("description", "test description");
 
-		// WHEN
-		try{
-			service.users().oid("123").modify(modifications).apost();
-		}catch(ObjectNotFoundException e){
-			fail("Bulk modification failed: " + e.getMessage());
-		}
+		ObjectReference<UserType> ref = service.users().oid("123").modify(modifications).post();
 
-		try{
-			service.users().oid("123").modify()
+		assertEquals(ref.getObject().getDescription(), "test description");
+
+		/*ref = service.users().oid("123").modify()
 					.add("givenName", service.util().createPoly("Example given name"))
-					.add("lastName", service.util().createPoly("Example last name"))
-					.apost();
-		}catch(ObjectNotFoundException e){
-			fail("Modification failed: " + e.getMessage());
-		}
+					.post();
+
+		UserType userType = ref.getObject();
+
+		assertEquals(userType.getGivenName().toString(), "Example given name");*/
+
 	}
 
 	@Test
 	public void test201UserDelete() throws Exception{
-		// SETUP
-	/*	Service service = getService();
-
-		// WHEN
-		try{
-			service.users().oid("123").delete();
-		}catch(ObjectNotFoundException e){
-			fail("Cannot delete user, user not found");
-		}*/
+//		// SETUP
+//		Service service = getService();
+//
+//		// WHEN
+//		try{
+//			service.users().oid("123").delete();
+//		}catch(ObjectNotFoundException e){
+//			fail("Cannot delete user, user not found");
+//		}
 	}
 	
 	@Test

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -129,10 +129,16 @@ public class TestBasic {
 		Map<String, Object> modifications = new HashMap<>();
 		modifications.put("description", "test description");
 
-		ObjectReference<UserType> ref = service.users().oid("123")
-				.modify(modifications) //TODO: Is this getting overwritten?
+		ObjectReference<UserType> ref = null;
+
+		try{
+			ref	= service.users().oid("123")
+				.modify(modifications)
 				.item("givenName", util.createPoly("Charlie"))
 				.post();
+		}catch(ObjectNotFoundException e){
+			fail("Cannot modify user, user not found");
+		}
 
 		UserType user = ref.get();
 

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
@@ -34,6 +34,12 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.namespace.QName;
 
+import com.evolveum.midpoint.client.api.ServiceUtil;
+import com.evolveum.midpoint.client.impl.restjaxb.RestJaxbServiceUtil;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
+import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 
@@ -89,7 +95,7 @@ public class MidpointMockRestService {
 			@Context MessageContext mc){
 		
 		OperationResultType result = new OperationResultType();
-		result.setOperation("Get object");;
+		result.setOperation("Get object");
 		T objectType = (T) objectMap.get(type).get(id);
 		
 		if (objectType == null) {
@@ -100,6 +106,40 @@ public class MidpointMockRestService {
 		
 		return Response.status(Status.OK).header("Content-Type", MediaType.APPLICATION_XML).entity(objectType).build();
 		
+	}
+
+	@POST
+	@Path("/{type}/{id}")
+	@Produces({MediaType.APPLICATION_XML})
+	public <T extends ObjectType> Response modifyObjectPost(@PathParam("type") String type, @PathParam("id") String id, ObjectModificationType object,
+	                                                        @QueryParam("options") List<String> options,
+	                                                        @Context UriInfo uriInfo, @Context MessageContext mc) {
+
+		RestJaxbServiceUtil util = new RestJaxbServiceUtil();
+		OperationResultType result = new OperationResultType();
+		result.setOperation("Modify object");
+
+		UserType objectType = (UserType) objectMap.get(type).get(id);
+
+		if (objectType == null) {
+			result.setStatus(OperationResultStatusType.FATAL_ERROR);
+			result.setMessage("User with oid " + id + " not found");
+			return RestMockServiceUtil.createResponse(Status.NOT_FOUND, result);
+		}
+
+		List<ItemDeltaType> deltaTypeList = object.getItemDelta();
+		ItemDeltaType delta1 = deltaTypeList.get(1);
+		String description = delta1.getValue().get(0).toString();
+		objectType.setDescription(description);
+
+		ItemDeltaType delta2 = deltaTypeList.get(0);
+		//String description = delta2.getValue().get(0);
+		objectType.setGivenName((PolyStringType)delta2.getValue().get(0));
+		//objectType.setDescription(deltaTypeList.get(0).getValue().get(0).toString());
+		//objectType.setGivenName((PolyStringType)deltaTypeList.get(1).getValue().get(0));
+
+		return Response.status(Status.NO_CONTENT).header("Content-Type", MediaType.APPLICATION_XML).entity(objectType).build();
+
 	}
 
 	@DELETE

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
@@ -115,6 +115,8 @@ public class MidpointMockRestService {
 	                                                        @QueryParam("options") List<String> options,
 	                                                        @Context UriInfo uriInfo, @Context MessageContext mc) {
 
+		//TODO: Should we make this generic or does this satisfy our needs for the test case?
+
 		RestJaxbServiceUtil util = new RestJaxbServiceUtil();
 		OperationResultType result = new OperationResultType();
 		result.setOperation("Modify object");
@@ -127,16 +129,15 @@ public class MidpointMockRestService {
 			return RestMockServiceUtil.createResponse(Status.NOT_FOUND, result);
 		}
 
+		//Grab changes from the ObjectModificationType
 		List<ItemDeltaType> deltaTypeList = object.getItemDelta();
+
 		ItemDeltaType delta1 = deltaTypeList.get(1);
 		String description = delta1.getValue().get(0).toString();
 		objectType.setDescription(description);
 
 		ItemDeltaType delta2 = deltaTypeList.get(0);
-		//String description = delta2.getValue().get(0);
 		objectType.setGivenName((PolyStringType)delta2.getValue().get(0));
-		//objectType.setDescription(deltaTypeList.get(0).getValue().get(0).toString());
-		//objectType.setGivenName((PolyStringType)deltaTypeList.get(1).getValue().get(0));
 
 		return Response.status(Status.NO_CONTENT).header("Content-Type", MediaType.APPLICATION_XML).entity(objectType).build();
 


### PR DESCRIPTION
I added support for a rough modifyObjectPost. I'm not sure exactly how much convenience we want to provide with the fluent API for this call as it could easily take a large amount of work to explicitly accommodate every attribute for every object. If that is what we want to do, that will certainly be nice for the user. For now though I created a quick-ish simple working solution that allows you to specify the modifications in two ways. 

The first is by passing in a Map<String, Object> to the modify() method with the attribute path as a string and the value as a generic object to accommodate the variety of value types required (PolyStringType, ActivationStatusType and etc). ex: 

Map<String, Object> modifications = new HashMap<>();
modifications.put("description", "test description");

ObjectReference<UserType> ref = service.users().oid("123")
				.modify(modifications)
				.post();

The second is by specifying each item to modify one at a time ex:

ObjectReference<UserType> ref = service.users().oid("123")
				.modify()
                                .item("givenName", util.createPoly("Charlie"))
                                .item("description", "description")
				.post();

As you can see I also implemented it in a similar fashion to addObject where a reference to the new object is returned after the modifications have been made. I thought it may be useful, what do you think?

I wrote a test and tested it against our midPoint deployment. I also created a mock endpoint, however it is currently hard-coded to accommodate my specific modifyObject test case based on modifying a user. To be honest I'm not exactly sure how I would go about creating a generic modifyObject endpoint without spending a lot of time figuring out how to accommodate all object types and I did not want to spend a lot of time on it if we are only needing it to validate a single test. 

Let me know your thoughts on how verbose this call should be in accommodating object attributes!