### PR TITLE
Added support for valuePolicies and generateValue

### DIFF
--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectGenerateService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectGenerateService.java
@@ -3,13 +3,10 @@ package com.evolveum.midpoint.client.api;
 import com.evolveum.midpoint.client.api.verb.Post;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
 
 /**
  * @author jakmor
  */
-public interface ObjectGenerateService<O extends ObjectType> extends Post<PolicyItemsDefinitionType>{
-
-    ObjectGenerateService<O> execute();
-    ObjectGenerateService<O> path(String path);
-    ObjectGenerateService<O> policy(String policyOid);
+public interface ObjectGenerateService<O extends ObjectType> extends Post<ObjectReference<O>>{
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectGenerateService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectGenerateService.java
@@ -1,0 +1,14 @@
+package com.evolveum.midpoint.client.api;
+
+import com.evolveum.midpoint.client.api.verb.Post;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
+/**
+ * @author jakmor
+ */
+public interface ObjectGenerateService<O extends ObjectType> extends Post<ObjectReference<O>>{
+
+    ObjectGenerateService<O> execute();
+    ObjectGenerateService<O> path(String path);
+    ObjectGenerateService<O> policy(String policyOid);
+}

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectGenerateService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectGenerateService.java
@@ -1,12 +1,13 @@
 package com.evolveum.midpoint.client.api;
 
 import com.evolveum.midpoint.client.api.verb.Post;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
 /**
  * @author jakmor
  */
-public interface ObjectGenerateService<O extends ObjectType> extends Post<ObjectReference<O>>{
+public interface ObjectGenerateService<O extends ObjectType> extends Post<PolicyItemsDefinitionType>{
 
     ObjectGenerateService<O> execute();
     ObjectGenerateService<O> path(String path);

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -1,5 +1,7 @@
 package com.evolveum.midpoint.client.api;
 
+import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.client.api.verb.Post;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
@@ -8,7 +10,10 @@ import java.util.Map;
 /**
  * @author jakmor
  */
-public interface ObjectModifyService <O extends ObjectType> extends Post<ObjectReference<O>>{
+public interface ObjectModifyService <O extends ObjectType> extends Post<ObjectReference<O>>
+{
 
     ObjectModifyService<O> item(String path, Object value);
+
+    ObjectGenerateService<O> generate(String path) throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -14,6 +14,4 @@ public interface ObjectModifyService <O extends ObjectType> extends Post<ObjectR
 {
 
     ObjectModifyService<O> item(String path, Object value);
-
-    ObjectGenerateService<O> generate(String path) throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
@@ -31,4 +31,5 @@ public interface ObjectService<O extends ObjectType> extends Get<O>, Delete<O>
 {
     ObjectModifyService<O> modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException;
     ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException;
+    ObjectGenerateService<O> modifyGenerate(String path) throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
@@ -31,5 +31,4 @@ public interface ObjectService<O extends ObjectType> extends Get<O>, Delete<O>
 {
     ObjectModifyService<O> modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException;
     ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException;
-    ObjectGenerateService<O> generate() throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
@@ -31,4 +31,5 @@ public interface ObjectService<O extends ObjectType> extends Get<O>, Delete<O>
 {
     ObjectModifyService<O> modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException;
     ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException;
+    ObjectGenerateService<O> generate() throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PolicyCollectionService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PolicyCollectionService.java
@@ -15,21 +15,13 @@
  */
 package com.evolveum.midpoint.client.api;
 
-import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ValuePolicyType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
 /**
- * @author semancik
+ * @author jakmor
  *
  */
-public interface Service {
-	
-	// TODO
-//	ProxyService proxy();
-
-	ObjectCollectionService<UserType> users();
-
-	PolicyCollectionService<ValuePolicyType> valuePolicies();
-	
-	ServiceUtil util();
+public interface PolicyCollectionService<O extends ObjectType> extends ObjectCollectionService<O> {
+	@Override
+	PolicyService<O> oid(String oid);
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PolicyGenerateService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PolicyGenerateService.java
@@ -1,0 +1,10 @@
+package com.evolveum.midpoint.client.api;
+
+import com.evolveum.midpoint.client.api.verb.Post;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
+/**
+ * @author jakmor
+ */
+public interface PolicyGenerateService extends Post<String>{
+}

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PolicyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PolicyService.java
@@ -15,21 +15,22 @@
  */
 package com.evolveum.midpoint.client.api;
 
-import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.client.api.verb.Delete;
+import com.evolveum.midpoint.client.api.verb.Get;
+import com.evolveum.midpoint.client.api.verb.Post;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ValuePolicyType;
 
+import java.util.Map;
+
 /**
- * @author semancik
+ * @author jakmor
  *
  */
-public interface Service {
-	
-	// TODO
-//	ProxyService proxy();
-
-	ObjectCollectionService<UserType> users();
-
-	PolicyCollectionService<ValuePolicyType> valuePolicies();
-	
-	ServiceUtil util();
+public interface PolicyService<O extends ObjectType> extends ObjectService<O>
+{
+    PolicyGenerateService generate();
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectGenerateService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectGenerateService.java
@@ -6,6 +6,7 @@ import com.evolveum.midpoint.client.api.TaskFuture;
 import com.evolveum.midpoint.client.api.exception.AuthenticationException;
 import com.evolveum.midpoint.client.api.exception.AuthorizationException;
 import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
 import com.sun.org.apache.xpath.internal.functions.FuncSubstring;
@@ -57,13 +58,13 @@ public class RestJaxbObjectGenerateService<O extends ObjectType> extends Abstrac
     {
         String oid = getOid();
         String restPath = RestUtil.subUrl(Types.findType(getType()).getRestPath(), oid);
-
-        Response response = getService().getClient().replacePath(restPath).post("");
+        restPath += "/generate";
+        Response response = getService().getClient().replacePath(restPath).post(RestUtil.buildGenerateObject(this.policyOid, this.path, this.execute));
 
         switch (response.getStatus()) {
-            case 204:
-                RestJaxbObjectReference<O> ref = new RestJaxbObjectReference<>(getService(), getType(), oid);
-                return new RestJaxbCompletedFuture<>(ref);
+            case 200:
+                PolicyItemsDefinitionType generationResult = response.readEntity(PolicyItemsDefinitionType.class);
+                return new RestJaxbCompletedFuture<>(generationResult);
             case 400:
                 throw new BadRequestException(response.getStatusInfo().getReasonPhrase());
             case 401:
@@ -76,9 +77,5 @@ public class RestJaxbObjectGenerateService<O extends ObjectType> extends Abstrac
             default:
                 throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
         }
-    }
-
-    private buildPolicyItemsDefinition(){
-
     }
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectGenerateService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectGenerateService.java
@@ -22,34 +22,14 @@ import java.util.Map;
 public class RestJaxbObjectGenerateService<O extends ObjectType> extends AbstractObjectWebResource<O> implements ObjectGenerateService<O>
 {
 
-    private static final String DEFAULT_PASS_POLICY_OID ="00000000-0000-0000-0000-000000000003";
-    private static final String DEFAULT_PASS_PATH = "/credentials/password/value";
 
-    private boolean execute = false;
-    private String path = DEFAULT_PASS_PATH ;
-    private String policyOid = DEFAULT_PASS_POLICY_OID;
+    private String path;
 
-    public RestJaxbObjectGenerateService(RestJaxbService service, Class<O> type, String oid)
+
+    public RestJaxbObjectGenerateService(RestJaxbService service, Class<O> type, String oid, String path)
     {
         super(service, type, oid);
-    }
-
-    @Override
-    public ObjectGenerateService<O> execute(){
-        this.execute = true;
-        return this;
-    }
-
-    @Override
-    public ObjectGenerateService<O> path(String path){
         this.path = path;
-        return this;
-    }
-
-    @Override
-    public ObjectGenerateService<O> policy(String policyOid){
-        this.policyOid = policyOid;
-        return this;
     }
 
 
@@ -59,12 +39,12 @@ public class RestJaxbObjectGenerateService<O extends ObjectType> extends Abstrac
         String oid = getOid();
         String restPath = RestUtil.subUrl(Types.findType(getType()).getRestPath(), oid);
         restPath += "/generate";
-        Response response = getService().getClient().replacePath(restPath).post(RestUtil.buildGenerateObject(this.policyOid, this.path, this.execute));
+        Response response = getService().getClient().replacePath(restPath).post(RestUtil.buildGenerateObject(this.path, true));
 
         switch (response.getStatus()) {
             case 200:
-                PolicyItemsDefinitionType generationResult = response.readEntity(PolicyItemsDefinitionType.class);
-                return new RestJaxbCompletedFuture<>(generationResult);
+                RestJaxbObjectReference<O> ref = new RestJaxbObjectReference<>(getService(), getType(), oid);
+                return new RestJaxbCompletedFuture<>(ref);
             case 400:
                 throw new BadRequestException(response.getStatusInfo().getReasonPhrase());
             case 401:

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectGenerateService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectGenerateService.java
@@ -1,0 +1,84 @@
+package com.evolveum.midpoint.client.impl.restjaxb;
+
+import com.evolveum.midpoint.client.api.ObjectGenerateService;
+import com.evolveum.midpoint.client.api.ObjectModifyService;
+import com.evolveum.midpoint.client.api.TaskFuture;
+import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.client.api.exception.AuthorizationException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
+import com.sun.org.apache.xpath.internal.functions.FuncSubstring;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author jakmor
+ */
+public class RestJaxbObjectGenerateService<O extends ObjectType> extends AbstractObjectWebResource<O> implements ObjectGenerateService<O>
+{
+
+    private static final String DEFAULT_PASS_POLICY_OID ="00000000-0000-0000-0000-000000000003";
+    private static final String DEFAULT_PASS_PATH = "/credentials/password/value";
+
+    private boolean execute = false;
+    private String path = DEFAULT_PASS_PATH ;
+    private String policyOid = DEFAULT_PASS_POLICY_OID;
+
+    public RestJaxbObjectGenerateService(RestJaxbService service, Class<O> type, String oid)
+    {
+        super(service, type, oid);
+    }
+
+    @Override
+    public ObjectGenerateService<O> execute(){
+        this.execute = true;
+        return this;
+    }
+
+    @Override
+    public ObjectGenerateService<O> path(String path){
+        this.path = path;
+        return this;
+    }
+
+    @Override
+    public ObjectGenerateService<O> policy(String policyOid){
+        this.policyOid = policyOid;
+        return this;
+    }
+
+
+    @Override
+    public TaskFuture apost() throws AuthorizationException, ObjectNotFoundException, AuthenticationException
+    {
+        String oid = getOid();
+        String restPath = RestUtil.subUrl(Types.findType(getType()).getRestPath(), oid);
+
+        Response response = getService().getClient().replacePath(restPath).post("");
+
+        switch (response.getStatus()) {
+            case 204:
+                RestJaxbObjectReference<O> ref = new RestJaxbObjectReference<>(getService(), getType(), oid);
+                return new RestJaxbCompletedFuture<>(ref);
+            case 400:
+                throw new BadRequestException(response.getStatusInfo().getReasonPhrase());
+            case 401:
+                throw new AuthenticationException(response.getStatusInfo().getReasonPhrase());
+            case 403:
+                throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
+                //TODO: Do we want to return a reference? Might be useful.
+            case 404:
+                throw new ObjectNotFoundException(response.getStatusInfo().getReasonPhrase());
+            default:
+                throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
+        }
+    }
+
+    private buildPolicyItemsDefinition(){
+
+    }
+}

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -1,5 +1,6 @@
 package com.evolveum.midpoint.client.impl.restjaxb;
 
+import com.evolveum.midpoint.client.api.ObjectGenerateService;
 import com.evolveum.midpoint.client.api.ObjectModifyService;
 import com.evolveum.midpoint.client.api.TaskFuture;
 import com.evolveum.midpoint.client.api.exception.*;
@@ -36,6 +37,12 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
     public RestJaxbObjectModifyService<O> item(String path, Object value){
         this.modifications.put(path, value);
         return this;
+    }
+
+
+    @Override
+    public ObjectGenerateService<O> generate(String path) throws ObjectNotFoundException, AuthenticationException{
+        return new RestJaxbObjectGenerateService<>(getService(), getType(), getOid(), path);
     }
 
     @Override

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -41,11 +41,6 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
 
 
     @Override
-    public ObjectGenerateService<O> generate(String path) throws ObjectNotFoundException, AuthenticationException{
-        return new RestJaxbObjectGenerateService<>(getService(), getType(), getOid(), path);
-    }
-
-    @Override
     public TaskFuture apost() throws AuthorizationException, ObjectNotFoundException, AuthenticationException
     {
         String oid = getOid();

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -56,9 +56,4 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	{
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid());
 	}
-
-	@Override
-	public ObjectGenerateService<O> generate() throws ObjectNotFoundException, AuthenticationException{
-		return new RestJaxbObjectGenerateService<>(getService(), getType(), getOid());
-	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -56,4 +56,9 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	{
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid());
 	}
+
+	@Override
+	public ObjectGenerateService<O> modifyGenerate(String path) throws ObjectNotFoundException, AuthenticationException{
+		return new RestJaxbObjectGenerateService<>(getService(), getType(), getOid(), path);
+	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -15,6 +15,7 @@
  */
 package com.evolveum.midpoint.client.impl.restjaxb;
 
+import com.evolveum.midpoint.client.api.ObjectGenerateService;
 import com.evolveum.midpoint.client.api.ObjectModifyService;
 import com.evolveum.midpoint.client.api.ObjectService;
 import com.evolveum.midpoint.client.api.exception.AuthenticationException;
@@ -38,7 +39,6 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 		return getService().getObject(getType(), getOid());
 	}
 
-
 	@Override
 	public void delete() throws ObjectNotFoundException, AuthenticationException
 	{
@@ -55,5 +55,9 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	public ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException
 	{
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid());
+	}
+
+	public ObjectGenerateService<O> generateService() throws ObjectNotFoundException, AuthenticationException{
+		return new RestJaxbObjectGenerateService<>(getService(), getType(), getOid());
 	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -57,7 +57,8 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid());
 	}
 
-	public ObjectGenerateService<O> generateService() throws ObjectNotFoundException, AuthenticationException{
+	@Override
+	public ObjectGenerateService<O> generate() throws ObjectNotFoundException, AuthenticationException{
 		return new RestJaxbObjectGenerateService<>(getService(), getType(), getOid());
 	}
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbPolicyCollectionService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbPolicyCollectionService.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2017 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.evolveum.midpoint.client.impl.restjaxb;
+
+import com.evolveum.midpoint.client.api.*;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
+/**
+ * @author jakmor
+ *
+ */
+public class RestJaxbPolicyCollectionService<O extends ObjectType> extends RestJaxbObjectCollectionService<O> implements PolicyCollectionService<O>{
+
+	public RestJaxbPolicyCollectionService(final RestJaxbService service, final String urlPrefix, final Class<O> type) {
+		super(service, urlPrefix, type);
+	}
+
+	@Override
+	public PolicyService<O> oid(String oid) {
+		return new RestJaxbPolicyService<>(getService(), getType(), oid);
+	}
+}

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbPolicyGenerateService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbPolicyGenerateService.java
@@ -1,0 +1,57 @@
+package com.evolveum.midpoint.client.impl.restjaxb;
+
+import com.evolveum.midpoint.client.api.ObjectGenerateService;
+import com.evolveum.midpoint.client.api.PolicyGenerateService;
+import com.evolveum.midpoint.client.api.TaskFuture;
+import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.client.api.exception.AuthorizationException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author jakmor
+ */
+public class RestJaxbPolicyGenerateService<O extends ObjectType> extends AbstractObjectWebResource<O> implements PolicyGenerateService
+{
+
+    private String path;
+
+    public RestJaxbPolicyGenerateService(RestJaxbService service, Class<O> type, String oid)
+    {
+        super(service, type, oid);
+        this.path = "description";
+    }
+
+
+    @Override
+    public TaskFuture apost() throws AuthorizationException, ObjectNotFoundException, AuthenticationException
+    {
+        String oid = getOid();
+        String restPath = RestUtil.subUrl(Types.findType(getType()).getRestPath(), oid);
+        restPath += "/generate";
+        Response response = getService().getClient().replacePath(restPath).post(RestUtil.buildGenerateObject(getOid(),this.path, false));
+
+        switch (response.getStatus()) {
+            case 200:
+                PolicyItemsDefinitionType itemsDefinitionType = response.readEntity(PolicyItemsDefinitionType.class);
+                return new RestJaxbCompletedFuture<>(RestUtil.getPolicyItemsDefValue(itemsDefinitionType));
+            case 400:
+                throw new BadRequestException(response.getStatusInfo().getReasonPhrase());
+            case 401:
+                throw new AuthenticationException(response.getStatusInfo().getReasonPhrase());
+            case 403:
+                throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
+                //TODO: Do we want to return a reference? Might be useful.
+            case 404:
+                throw new ObjectNotFoundException(response.getStatusInfo().getReasonPhrase());
+            default:
+                throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
+        }
+    }
+
+
+}

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbPolicyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbPolicyService.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.evolveum.midpoint.client.impl.restjaxb;
+
+import com.evolveum.midpoint.client.api.ObjectModifyService;
+import com.evolveum.midpoint.client.api.ObjectService;
+import com.evolveum.midpoint.client.api.PolicyGenerateService;
+import com.evolveum.midpoint.client.api.PolicyService;
+import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ValuePolicyType;
+
+import java.util.Map;
+
+/**
+ * @author jakmor
+ *
+ */
+public class RestJaxbPolicyService<O extends ObjectType> extends RestJaxbObjectService<O> implements PolicyService<O>
+{
+
+	public RestJaxbPolicyService(final RestJaxbService service, final Class<O> type, final String oid) {
+		super(service, type, oid);
+	}
+
+	@Override
+	public PolicyGenerateService generate()
+	{
+		return new RestJaxbPolicyGenerateService<>(getService(),getType(), getOid());
+	}
+}

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -30,6 +30,8 @@ import javax.xml.bind.JAXBException;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.evolveum.midpoint.client.api.PolicyCollectionService;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ValuePolicyType;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
@@ -137,6 +139,10 @@ public class RestJaxbService implements Service {
 		return new RestJaxbObjectCollectionService<>(this, URL_PREFIX_USERS, UserType.class);
 	}
 
+	@Override
+	public PolicyCollectionService<ValuePolicyType> valuePolicies() {
+		return new RestJaxbPolicyCollectionService<>(this, URL_PREFIX_USERS, ValuePolicyType.class);
+	}
 	@Override
 	public ServiceUtil util() {
 		return util;

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbServiceUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbServiceUtil.java
@@ -61,4 +61,6 @@ public class RestJaxbServiceUtil implements ServiceUtil {
 		Arrays.asList(qname).forEach(name -> itemPathType.setValue(itemPathType + "/" + name.getLocalPart()));
 		return itemPathType;
 	}
+
+
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
@@ -79,6 +79,9 @@ public class RestUtil {
 
 		return itemDeltaType;
 	}
+	public static PolicyItemsDefinitionType buildGenerateObject(String targetPath, Boolean execute){
+		return buildGenerateObject("", targetPath,execute);
+	}
 
 	public static PolicyItemsDefinitionType buildGenerateObject(String policyOid, String targetPath, Boolean execute)
 	{
@@ -92,9 +95,11 @@ public class RestUtil {
 		targetType.setPath(itemPathType);
 		policyItemDefinitionType.setTarget(targetType);
 
-		//Set valuePolicyRef
-		policyItemDefinitionType.setValuePolicyRef(buildValuePolicyRef(policyOid));
-
+		if(!"".equals(policyOid))
+		{
+			//Set valuePolicyRef
+			policyItemDefinitionType.setValuePolicyRef(buildValuePolicyRef(policyOid));
+		}
 		//Set Execute
 		policyItemDefinitionType.setExecute(execute);
 

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
@@ -16,10 +16,15 @@
 package com.evolveum.midpoint.client.impl.restjaxb;
 
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemTargetType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectReferenceType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
 
+import javax.xml.namespace.QName;
 import java.util.Map;
 
 /**
@@ -27,6 +32,8 @@ import java.util.Map;
  *
  */
 public class RestUtil {
+
+	private final String NS_COMMON = "http://midpoint.evolveum.com/xml/ns/public/common/common-3";
 	
 	public static String subUrl(final String urlPrefix, final String pathSegment) {
 		// TODO: better code (e.g. escaping)
@@ -72,6 +79,39 @@ public class RestUtil {
 
 		return itemDeltaType;
 	}
+
+	private PolicyItemsDefinitionType buildGenerateObject(String policyOid, String targetPath, Boolean execute)
+	{
+		PolicyItemsDefinitionType policyItemsDefinitionType = new PolicyItemsDefinitionType();
+		PolicyItemDefinitionType policyItemDefinitionType = new PolicyItemDefinitionType();
+
+		//Set target path
+		ItemPathType itemPathType = new ItemPathType();
+		itemPathType.setValue(targetPath);
+		PolicyItemTargetType targetType = new PolicyItemTargetType();
+		targetType.setPath(itemPathType);
+		policyItemDefinitionType.setTarget(targetType);
+
+		//Set valuePolicyRef
+		policyItemDefinitionType.setValuePolicyRef(buildValuePolicyRef(policyOid));
+
+		//Set Execute
+		policyItemDefinitionType.setExecute(execute);
+
+		policyItemsDefinitionType.getPolicyItemDefinition().add(policyItemDefinitionType);
+		return policyItemsDefinitionType;
+	}
+
+	private ObjectReferenceType buildValuePolicyRef(String policyOid)
+	{
+		ObjectReferenceType objectReferenceType = new ObjectReferenceType();
+		objectReferenceType.setOid(policyOid);
+		QName qname = new QName(NS_COMMON, "ValuePolicyType");
+		objectReferenceType.setType(qname);
+		return objectReferenceType;
+	}
+
+
 	
 
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
@@ -33,7 +33,7 @@ import java.util.Map;
  */
 public class RestUtil {
 
-	private final String NS_COMMON = "http://midpoint.evolveum.com/xml/ns/public/common/common-3";
+	private static final String NS_COMMON = "http://midpoint.evolveum.com/xml/ns/public/common/common-3";
 	
 	public static String subUrl(final String urlPrefix, final String pathSegment) {
 		// TODO: better code (e.g. escaping)
@@ -80,7 +80,7 @@ public class RestUtil {
 		return itemDeltaType;
 	}
 
-	private PolicyItemsDefinitionType buildGenerateObject(String policyOid, String targetPath, Boolean execute)
+	public static PolicyItemsDefinitionType buildGenerateObject(String policyOid, String targetPath, Boolean execute)
 	{
 		PolicyItemsDefinitionType policyItemsDefinitionType = new PolicyItemsDefinitionType();
 		PolicyItemDefinitionType policyItemDefinitionType = new PolicyItemDefinitionType();
@@ -102,7 +102,7 @@ public class RestUtil {
 		return policyItemsDefinitionType;
 	}
 
-	private ObjectReferenceType buildValuePolicyRef(String policyOid)
+	private static ObjectReferenceType buildValuePolicyRef(String policyOid)
 	{
 		ObjectReferenceType objectReferenceType = new ObjectReferenceType();
 		objectReferenceType.setOid(policyOid);

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
@@ -23,8 +23,12 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectReferenceType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
+import com.sun.org.apache.xerces.internal.dom.ElementNSImpl;
+import com.sun.org.apache.xerces.internal.dom.TextImpl;
 
+import javax.ws.rs.core.AbstractMultivaluedMap;
 import javax.xml.namespace.QName;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -116,7 +120,14 @@ public class RestUtil {
 		return objectReferenceType;
 	}
 
-
+	public static String getPolicyItemsDefValue(PolicyItemsDefinitionType policyItems){
+		List<PolicyItemDefinitionType> resultList = policyItems.getPolicyItemDefinition();
+		PolicyItemDefinitionType policyItemDefinitionType = resultList.get(0);
+		//Why cant getValue just return the string value? :(
+		ElementNSImpl elementNSImpl = (ElementNSImpl) policyItemDefinitionType.getValue();
+		TextImpl textImpl = (TextImpl) elementNSImpl.getFirstChild();
+		return textImpl.getData();
+	}
 	
 
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/Types.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/Types.java
@@ -17,12 +17,14 @@ package com.evolveum.midpoint.client.impl.restjaxb;
 
 import java.util.Arrays;
 
+import javax.jws.Oneway;
 import javax.xml.namespace.QName;
 
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectListType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ValuePolicyType;
 import com.evolveum.prism.xml.ns._public.query_3.QueryType;
 
 /**
@@ -36,8 +38,8 @@ public enum Types {
 	QUERY(QueryType.class, new QName(SchemaConstants.NS_QUERY, "query"), null),
 	OBJECT_LIST_TYPE(ObjectListType.class, new QName(SchemaConstants.NS_API_TYPES, "objectList"), ""),
 	POLICY_ITEMS_DEFINITION(PolicyItemsDefinitionType.class, new QName(SchemaConstants.NS_API_TYPES, "policyItemsDefinition"), ""),
-	OBJECT_MODIFICATION_TYPE(ObjectModificationType.class, new QName(SchemaConstants.NS_API_TYPES, "objectModification"), "");
-	
+	OBJECT_MODIFICATION_TYPE(ObjectModificationType.class, new QName(SchemaConstants.NS_API_TYPES, "objectModification"), ""),
+	VALUE_POLICIES(ValuePolicyType.class, new QName(SchemaConstants.NS_COMMON, "valuePolicy"), "valuePolicies");
 	
 	
 	private Class<?> clazz;

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -35,6 +35,7 @@ import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefini
 import com.evolveum.prism.xml.ns._public.types_3.ProtectedStringType;
 import com.sun.org.apache.xerces.internal.dom.ElementNSImpl;
 import com.sun.org.apache.xerces.internal.dom.TextImpl;
+import com.sun.org.apache.xpath.internal.functions.FuncSubstring;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
@@ -255,11 +256,10 @@ public class TestBasic {
 	{
 		Service service = getService();
 
-		ObjectReference<UserType> userRef = service.users().oid("123").modify().generate("credentials/password/value").post();
+		ObjectReference<UserType> userRef = service.users().oid("123").modify().generate("description").post();
 		UserType user = userRef.get();
 		ProtectedStringType password = user.getCredentials().getPassword().getValue();
-
-		//TODO: Finish test
+		assertNotNull(password);
 	}
 
 	@Test
@@ -269,23 +269,6 @@ public class TestBasic {
 		String generatedPassword = service.valuePolicies().oid("00000000-0000-0000-0000-000000000003").generate().post();
 		assertNotNull(generatedPassword);
 	}
-/*
-	@Test
-	public void test202generateImplicit() throws Exception
-	{
-		Service service = getService();
-
-		service.users().oid("123").generate().path().post();
-	}
-
-	@Test
-	public void test203generateExecute() throws Exception
-	{
-		Service service = getService();
-
-		service.users().oid("123").generate().path().execute.post();
-	}*/
-
 	
 private Service getService() throws IOException {
 		

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -255,7 +255,7 @@ public class TestBasic {
 	public void test201modifyGenerate() throws Exception
 	{
 		Service service = getService();
-		ObjectReference<UserType> userRef = service.users().oid("123").modify().generate("givenName").post();
+		ObjectReference<UserType> userRef = service.users().oid("123").modifyGenerate("givenName").post();
 		UserType user = userRef.get();
 		assertNotNull(service.util().getOrig(user.getGivenName()));
 	}

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -148,7 +148,7 @@ public class TestBasic {
 	}
 
 	@Test
-	public void test201UserDelete() throws Exception{
+	public void test900UserDelete() throws Exception{
 		// SETUP
 		Service service = getService();
 
@@ -242,6 +242,32 @@ public class TestBasic {
 		
 		
 	}
+
+/*	@Test
+	public void test201generateExplicit() throws Exception
+	{
+		Service service = getService();
+
+
+		service.users().oid("123").generate().policy().post();
+	}
+
+	@Test
+	public void test202generateImplicit() throws Exception
+	{
+		Service service = getService();
+
+		service.users().oid("123").generate().path().post();
+	}
+
+	@Test
+	public void test203generateExecute() throws Exception
+	{
+		Service service = getService();
+
+		service.users().oid("123").generate().path().execute.post();
+	}*/
+
 	
 private Service getService() throws IOException {
 		

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -251,16 +251,23 @@ public class TestBasic {
 	}
 
 	@Test
-	public void test201generateExplicit() throws Exception
+	public void test201modifyGenerate() throws Exception
 	{
 		Service service = getService();
 
 		ObjectReference<UserType> userRef = service.users().oid("123").modify().generate("credentials/password/value").post();
 		UserType user = userRef.get();
 		ProtectedStringType password = user.getCredentials().getPassword().getValue();
-		password.getContent().get(0).toString();
 
-		System.out.println(password.getContent().get(0).toString());
+		//TODO: Finish test
+	}
+
+	@Test
+	public void test201policyGenerate() throws Exception
+	{
+		Service service = getService();
+		String generatedPassword = service.valuePolicies().oid("00000000-0000-0000-0000-000000000003").generate().post();
+		assertNotNull(generatedPassword);
 	}
 /*
 	@Test

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -32,6 +32,7 @@ import javax.xml.bind.JAXBException;
 import com.evolveum.midpoint.client.api.ServiceUtil;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
+import com.evolveum.prism.xml.ns._public.types_3.ProtectedStringType;
 import com.sun.org.apache.xerces.internal.dom.ElementNSImpl;
 import com.sun.org.apache.xerces.internal.dom.TextImpl;
 import org.apache.cxf.endpoint.Server;
@@ -153,18 +154,18 @@ public class TestBasic {
 		assertEquals(util.getOrig(user.getGivenName()), "Charlie");
 	}
 
-	@Test
-	public void test900UserDelete() throws Exception{
-		// SETUP
-		Service service = getService();
-
-		// WHEN
-		try{
-			service.users().oid("123").delete();
-		}catch(ObjectNotFoundException e){
-			fail("Cannot delete user, user not found");
-		}
-	}
+//	@Test
+//	public void test900UserDelete() throws Exception{
+//		// SETUP
+//		Service service = getService();
+//
+//		// WHEN
+//		try{
+//			service.users().oid("123").delete();
+//		}catch(ObjectNotFoundException e){
+//			fail("Cannot delete user, user not found");
+//		}
+//	}
 	
 	@Test
 	public void test010UserSearch() throws Exception {
@@ -254,17 +255,12 @@ public class TestBasic {
 	{
 		Service service = getService();
 
+		ObjectReference<UserType> userRef = service.users().oid("123").modify().generate("credentials/password/value").post();
+		UserType user = userRef.get();
+		ProtectedStringType password = user.getCredentials().getPassword().getValue();
+		password.getContent().get(0).toString();
 
-		 PolicyItemsDefinitionType result = service.users().oid("123").generate().post();
-
-		List<PolicyItemDefinitionType> resultList = result.getPolicyItemDefinition();
-		PolicyItemDefinitionType policyItemDefinitionType = resultList.get(0);
-		//Why cant getValue just return the string value? :(
-		ElementNSImpl elementNSImpl = (ElementNSImpl) policyItemDefinitionType.getValue();
-		TextImpl textImpl = (TextImpl) elementNSImpl.getFirstChild();
-		String value = textImpl.getData();
-
-		System.out.println(value);
+		System.out.println(password.getContent().get(0).toString());
 	}
 /*
 	@Test

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -62,12 +62,12 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 public class TestBasic {
 	
 	private static Server server;
-	//private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
-	private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
+	private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
+	//private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
 
 	@BeforeClass
 	public void init() throws IOException {
-		//startServer();
+		startServer();
 	}
 	
 	@Test
@@ -255,15 +255,13 @@ public class TestBasic {
 	public void test201modifyGenerate() throws Exception
 	{
 		Service service = getService();
-
-		ObjectReference<UserType> userRef = service.users().oid("123").modify().generate("description").post();
+		ObjectReference<UserType> userRef = service.users().oid("123").modify().generate("givenName").post();
 		UserType user = userRef.get();
-		ProtectedStringType password = user.getCredentials().getPassword().getValue();
-		assertNotNull(password);
+		assertNotNull(service.util().getOrig(user.getGivenName()));
 	}
 
 	@Test
-	public void test201policyGenerate() throws Exception
+	public void test202policyGenerate() throws Exception
 	{
 		Service service = getService();
 		String generatedPassword = service.valuePolicies().oid("00000000-0000-0000-0000-000000000003").generate().post();

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -25,15 +25,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.core.Response;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 
 import com.evolveum.midpoint.client.api.ServiceUtil;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
+import com.sun.org.apache.xerces.internal.dom.ElementNSImpl;
+import com.sun.org.apache.xerces.internal.dom.TextImpl;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.jaxrs.lifecycle.SingletonResourceProvider;
 import org.apache.cxf.transport.local.LocalConduit;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -54,12 +60,12 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 public class TestBasic {
 	
 	private static Server server;
-	private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
-	//private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
+	//private static final String ENDPOINT_ADDRESS = "http://localhost:18080/rest";
+	private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
 
 	@BeforeClass
 	public void init() throws IOException {
-		startServer();
+		//startServer();
 	}
 	
 	@Test
@@ -243,15 +249,24 @@ public class TestBasic {
 		
 	}
 
-/*	@Test
+	@Test
 	public void test201generateExplicit() throws Exception
 	{
 		Service service = getService();
 
 
-		service.users().oid("123").generate().policy().post();
-	}
+		 PolicyItemsDefinitionType result = service.users().oid("123").generate().post();
 
+		List<PolicyItemDefinitionType> resultList = result.getPolicyItemDefinition();
+		PolicyItemDefinitionType policyItemDefinitionType = resultList.get(0);
+		//Why cant getValue just return the string value? :(
+		ElementNSImpl elementNSImpl = (ElementNSImpl) policyItemDefinitionType.getValue();
+		TextImpl textImpl = (TextImpl) elementNSImpl.getFirstChild();
+		String value = textImpl.getData();
+
+		System.out.println(value);
+	}
+/*
 	@Test
 	public void test202generateImplicit() throws Exception
 	{

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
@@ -28,27 +28,32 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import javax.xml.bind.*;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import com.evolveum.midpoint.client.api.ServiceUtil;
 import com.evolveum.midpoint.client.impl.restjaxb.RestJaxbServiceUtil;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
 import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
+import com.sun.org.apache.xerces.internal.dom.ElementNSImpl;
+import com.sun.org.apache.xerces.internal.dom.TextImpl;
+import com.sun.xml.internal.messaging.saaj.soap.impl.ElementImpl;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 
 import com.evolveum.midpoint.client.impl.restjaxb.SchemaConstants;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectListType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultStatusType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultType;
 import com.evolveum.prism.xml.ns._public.query_3.QueryType;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 /**
  * 
@@ -61,9 +66,13 @@ public class MidpointMockRestService {
 		private  Map<String, Map<String, ObjectType>> objectMap = new HashMap<>();
 	
 		private Map<String, ObjectType> userMap = new HashMap<>();
+		private Map<String, ObjectType> valuePolicyMap = new HashMap<>();
 		
 		public MidpointMockRestService() {
 			objectMap.put("users", userMap);
+
+			valuePolicyMap.put("00000000-0000-0000-0000-000000000003", new ValuePolicyType());
+			objectMap.put("valuePolicies", valuePolicyMap);
 		}
 	
 	@POST
@@ -109,9 +118,98 @@ public class MidpointMockRestService {
 	}
 
 	@POST
+	@Path("/valuePolicies/{id}/generate")
+	@Produces({MediaType.APPLICATION_XML})
+	public Response policyGenerate(@PathParam("id") String id,
+	                                                PolicyItemsDefinitionType object,
+	                                                 @QueryParam("options") List<String> options,
+	                                                 @QueryParam("include") List<String> include,
+	                                                 @QueryParam("exclude") List<String> exclude,
+	                                                 @Context MessageContext mc){
+
+		OperationResultType result = new OperationResultType();
+		result.setOperation("Policy generate");
+
+		String policyOid = object.getPolicyItemDefinition().get(0).getValuePolicyRef().getOid();
+		ValuePolicyType policy = (ValuePolicyType)objectMap.get("valuePolicies").get(policyOid);
+
+		if (policy == null) {
+			result.setStatus(OperationResultStatusType.FATAL_ERROR);
+			result.setMessage("Policy with oid " + id + " not found");
+			return RestMockServiceUtil.createResponse(Status.NOT_FOUND, result);
+		}
+
+		try
+		{
+			DocumentBuilderFactory dFact = DocumentBuilderFactory.newInstance();
+			DocumentBuilder build = dFact.newDocumentBuilder();
+			Document doc = build.newDocument();
+			Element value = doc.createElement("value");
+			Node node = doc.createTextNode("dj38dj");
+			value.appendChild(node);
+			object.getPolicyItemDefinition().get(0).setValue(value);
+
+		}
+		catch(ParserConfigurationException e){
+			result.setStatus(OperationResultStatusType.FATAL_ERROR);
+			result.setMessage("Failure creating response");
+			return RestMockServiceUtil.createResponse(Status.INTERNAL_SERVER_ERROR, result);
+		}
+
+		return Response.status(Status.OK).header("Content-Type", MediaType.APPLICATION_XML).entity(object).build();
+	}
+
+	@POST
+	@Path("/{type}/{id}/generate")
+	@Produces({MediaType.APPLICATION_XML})
+	public <T extends ObjectType> Response modifyGenerate(@PathParam("type") String type, @PathParam("id") String id,
+	                                                      PolicyItemsDefinitionType object,
+	                                                      @QueryParam("options") List<String> options,
+	                                                      @QueryParam("include") List<String> include,
+	                                                      @QueryParam("exclude") List<String> exclude,
+	                                                      @Context MessageContext mc){
+
+		OperationResultType result = new OperationResultType();
+		result.setOperation("Modify generate object");
+		UserType user = (UserType) objectMap.get(type).get(id);
+
+		if (user == null) {
+			result.setStatus(OperationResultStatusType.FATAL_ERROR);
+			result.setMessage("User with oid " + id + " not found");
+			return RestMockServiceUtil.createResponse(Status.NOT_FOUND, result);
+		}
+
+		String newValue = "Bob";
+
+		try
+		{
+			DocumentBuilderFactory dFact = DocumentBuilderFactory.newInstance();
+			DocumentBuilder build = dFact.newDocumentBuilder();
+			Document doc = build.newDocument();
+			Element value = doc.createElement("value");
+			Node node = doc.createTextNode(newValue);
+			value.appendChild(node);
+			object.getPolicyItemDefinition().get(0).setValue(value);
+
+		}
+		catch(ParserConfigurationException e){
+			result.setStatus(OperationResultStatusType.FATAL_ERROR);
+			result.setMessage("Failure creating response");
+			return RestMockServiceUtil.createResponse(Status.INTERNAL_SERVER_ERROR, result);
+		}
+
+		RestJaxbServiceUtil util = new RestJaxbServiceUtil();
+
+		user.setGivenName(util.createPoly(newValue));
+
+		return Response.status(Status.OK).header("Content-Type", MediaType.APPLICATION_XML).entity(object).build();
+	}
+
+	@POST
 	@Path("/{type}/{id}")
 	@Produces({MediaType.APPLICATION_XML})
-	public <T extends ObjectType> Response modifyObjectPost(@PathParam("type") String type, @PathParam("id") String id, ObjectModificationType object,
+	public <T extends ObjectType> Response modifyObjectPost(@PathParam("type") String type, @PathParam("id") String id,
+	                                                        ObjectModificationType object,
 	                                                        @QueryParam("options") List<String> options,
 	                                                        @Context UriInfo uriInfo, @Context MessageContext mc) {
 
@@ -140,7 +238,6 @@ public class MidpointMockRestService {
 		objectType.setGivenName((PolyStringType)delta2.getValue().get(0));
 
 		return Response.status(Status.NO_CONTENT).header("Content-Type", MediaType.APPLICATION_XML).entity(objectType).build();
-
 	}
 
 	@DELETE


### PR DESCRIPTION
Firstly, I apologize for this pull request being a bit large - I had to add a bit to accommodate these use cases for generateValue.

For ease of use and for, in my opinion, more logical use, there are two different forms of generateValue here. Instead of trying to create one generate service that accommodates all generate situations, I broke it up into two main services, one generic service for generating a value implicitly and executing it, effectively modifying the object, and a policy generation service that simply returns a generated value based on the policy. 

The first service is called ObjectGenerateService. The method to call this is called modifyGenerate() and you simply pass in the path of an attribute that has an associated valuePolicy and it will be generated and provisioned. This returns an object reference just like modify and add. Right now this is called like this:

service().users().oid("123").modifyGenerate("/credentials/password/value").post();

What I want to do eventually is group it under modify like this:

service().users().oid("123").modify().generate("/credentials/password/value").post();

That will require more work and I also want to update modify() first to properly accommodate all modification types (add, replace, delete) like we discussed.  For now though, this is a working implementation and I think it makes sense to label it as a modify because it truly is modifying the object, just with a generated value. Perhaps even in the future ModifcationTypeType.GENERATE could be added as a part of modifyObject.

The second service is called PolicyGenerateService and is called with the generate() method. This service is only available to valuePolicies(). To accommodate that I had to add a PolicyService, and a PolicyCollectionService. If you think there is a better design to restrict the generate() call to valuePolicies without adding those additional classes please let me know. The reason I did this was to be able to simply pass in the OID of a valuePolicy and have a generated value returned like this:

String generatedValue = service.valuePolicies().oid("321").generate().post();

It doesn't make sense to me to allow objects of other types to be able to make explicit generate value calls which is why it has been restricted to valuePolicies(). This will also help in restricting explicit validates the same way.

I hope this design choice makes sense. 