### PR TITLE
Added add(), replace(), and delete() methods for modifyObject

### DIFF
--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -10,5 +10,10 @@ import java.util.Map;
  */
 public interface ObjectModifyService <O extends ObjectType> extends Post<ObjectReference<O>>{
 
-    ObjectModifyService<O> item(String path, Object value);
+    ObjectModifyService<O> add(String path, Object value);
+    ObjectModifyService<O> add(Map<String, Object> modifications);
+    ObjectModifyService<O> replace(String path, Object value);
+    ObjectModifyService<O> replace(Map<String, Object> modifications);
+    ObjectModifyService<O> delete(String path, Object value);
+    ObjectModifyService<O> delete(Map<String, Object> modifications);
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
@@ -29,6 +29,5 @@ import java.util.Map;
  */
 public interface ObjectService<O extends ObjectType> extends Get<O>, Delete<O>
 {
-    ObjectModifyService<O> modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException;
     ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -46,12 +46,6 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	}
 
 	@Override
-	public ObjectModifyService<O> modify(Map<String, Object> modifications) throws ObjectNotFoundException, AuthenticationException
-	{
-		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid(), modifications);
-	}
-
-	@Override
 	public ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException
 	{
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid());

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestUtil.java
@@ -20,6 +20,7 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,19 +34,12 @@ public class RestUtil {
 		return "/" + urlPrefix + "/" + pathSegment;
 	}
 
-	//TODO: If these work, item to interface
-	public static ObjectModificationType buildModifyObject(String path, Object value, ModificationTypeType modificationType)
-	{
-		ObjectModificationType objectModificationType = new ObjectModificationType();
-		objectModificationType.getItemDelta().add(buildItemDelta(modificationType, path, value));
-		return objectModificationType;
-	}
 
-	public static ObjectModificationType buildModifyObject(Map<String, Object> pathValueMap, ModificationTypeType modificationType)
+	public static ObjectModificationType buildModifyObject(List<ItemDeltaType> itemDeltas)
 	{
 		ObjectModificationType objectModificationType = new ObjectModificationType();
-		pathValueMap.forEach((path, value) ->
-				objectModificationType.getItemDelta().add(buildItemDelta(modificationType, path, value)));
+		itemDeltas.forEach((itemDelta) ->
+				objectModificationType.getItemDelta().add(itemDelta));
 
 		return objectModificationType;
 	}
@@ -61,13 +55,6 @@ public class RestUtil {
 		itemPathType.setValue(path);
 		itemDeltaType.setPath(itemPathType);
 
-		//Set Value
-		//TODO: Refactor. This really sucks. Passing an Object is very open-ended here.
-		//This is done because currently when a string value is marshalled to xml it gets a type attribute
-		//on it. That type attribute can cause conflicts depending on the attribute being updated.
-		//For example, if updating GivenName, an error would be thrown as midpoint is expecting a polyStringType.
-		//This is probably a namespacing issue. The current marshalling process is not robust enough to handle it and
-		//still be generic.
 		itemDeltaType.getValue().add(value);
 
 		return itemDeltaType;

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -151,28 +151,6 @@ public class TestBasic {
 
 	}
 
-//	@Test
-//	public void test006UserModifyDelete() throws Exception{
-//		Service service = getService();
-//		ServiceUtil util = service.util();
-//
-//
-//		ObjectReference<UserType> ref = null;
-//
-//		try{
-//			ref	= service.users().oid("123")
-//					.modify()
-//					.delete("givenName", "Charlie")
-//					.post();
-//		}catch(ObjectNotFoundException e){
-//			fail("Cannot modify user, user not found");
-//		}
-//
-//		UserType user = ref.get();
-//		assertEquals(user.getDescription(), "test description");
-//		assertEquals(util.getOrig(user.getGivenName()), "Charlie");
-//	}
-
 	@Test
 	public void test201UserDelete() throws Exception{
 		// SETUP

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -133,19 +133,45 @@ public class TestBasic {
 
 		try{
 			ref	= service.users().oid("123")
-				.modify(modifications)
-				.item("givenName", util.createPoly("Charlie"))
-				.post();
+					.modify()
+					.replace(modifications)
+					.add("givenName", util.createPoly("Charlie"))
+					.post();
 		}catch(ObjectNotFoundException e){
 			fail("Cannot modify user, user not found");
 		}
 
 		UserType user = ref.get();
-
 		assertEquals(user.getDescription(), "test description");
-
 		assertEquals(util.getOrig(user.getGivenName()), "Charlie");
+
+		ref	= service.users().oid("123").modify().delete("givenName", util.createPoly("Charlie")).post();
+
+		assertEquals(ref.get().getGivenName(), null);
+
 	}
+
+//	@Test
+//	public void test006UserModifyDelete() throws Exception{
+//		Service service = getService();
+//		ServiceUtil util = service.util();
+//
+//
+//		ObjectReference<UserType> ref = null;
+//
+//		try{
+//			ref	= service.users().oid("123")
+//					.modify()
+//					.delete("givenName", "Charlie")
+//					.post();
+//		}catch(ObjectNotFoundException e){
+//			fail("Cannot modify user, user not found");
+//		}
+//
+//		UserType user = ref.get();
+//		assertEquals(user.getDescription(), "test description");
+//		assertEquals(util.getOrig(user.getGivenName()), "Charlie");
+//	}
 
 	@Test
 	public void test201UserDelete() throws Exception{

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
@@ -39,6 +39,7 @@ import com.evolveum.midpoint.client.impl.restjaxb.RestJaxbServiceUtil;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
+import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
 import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.cxf.jaxrs.ext.MessageContext;
@@ -132,12 +133,18 @@ public class MidpointMockRestService {
 		//Grab changes from the ObjectModificationType
 		List<ItemDeltaType> deltaTypeList = object.getItemDelta();
 
-		ItemDeltaType delta1 = deltaTypeList.get(1);
-		String description = delta1.getValue().get(0).toString();
-		objectType.setDescription(description);
+		for(ItemDeltaType delta : deltaTypeList){
+			if(delta.getModificationType() == ModificationTypeType.ADD){
+				objectType.setGivenName((PolyStringType)delta.getValue().get(0));
+			}
+			else if(delta.getModificationType() == ModificationTypeType.REPLACE){
 
-		ItemDeltaType delta2 = deltaTypeList.get(0);
-		objectType.setGivenName((PolyStringType)delta2.getValue().get(0));
+				objectType.setDescription(delta.getValue().get(0).toString());
+			}
+			else{ //ModificationTypeType.DELETE
+				objectType.setGivenName(null);
+			}
+		}
 
 		return Response.status(Status.NO_CONTENT).header("Content-Type", MediaType.APPLICATION_XML).entity(objectType).build();
 


### PR DESCRIPTION
I did a slight overhaul of the modifyObject functionality. It now properly supports modification types add, replace, and delete. They can be stacked as one would expect and can either take a single path and value or a map of paths and values. Ex:

service.users().oid("123").modify()
                                        .add("description", "New description")
                                        .replace(replacementsMap)
                                        .delete("givenName")
                                        .post();

The tests and mock service have also been updated. Tested on local midPoint deployment as well. 