### PR TITLE
Update query builder -  paging and matching rules

### DIFF
--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PagingRuleBuilder.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PagingRuleBuilder.java
@@ -1,0 +1,22 @@
+package com.evolveum.midpoint.client.api;
+
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
+
+/**
+ * @author jakmor
+ */
+public interface PagingRuleBuilder <O extends ObjectType>
+{
+    /**
+     * Paging rules
+     */
+    public PagingRuleBuilder<O> orderBy(ItemPathType itemPath);
+    public PagingRuleBuilder<O> offSet(Integer offsetAmount);
+    public PagingRuleBuilder<O> maxSize(Integer size);
+    public PagingRuleBuilder<O> groupBy(ItemPathType itemPath);
+
+    public  QueryBuilder<O> finishPaging();
+
+
+}

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PagingRuleBuilder.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/PagingRuleBuilder.java
@@ -8,15 +8,10 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
  */
 public interface PagingRuleBuilder <O extends ObjectType>
 {
-    /**
-     * Paging rules
-     */
     public PagingRuleBuilder<O> orderBy(ItemPathType itemPath);
     public PagingRuleBuilder<O> offSet(Integer offsetAmount);
     public PagingRuleBuilder<O> maxSize(Integer size);
     public PagingRuleBuilder<O> groupBy(ItemPathType itemPath);
 
     public  QueryBuilder<O> finishPaging();
-
-
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/QueryBuilder.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/QueryBuilder.java
@@ -41,9 +41,10 @@ public interface QueryBuilder<O extends ObjectType> extends Get<SearchResult<O>>
 	
 	public ConditionEntryBuilder<O> item(ItemPathType itemPath); 
 	public ConditionEntryBuilder<O> item(QName... qnames);
+
+	public PagingRuleBuilder<O> paging();
 	
-	
-	
+
 	/**
 	 * Shortcut.
 	 * From: r.query().item(x).eq(y).build().get();

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/DomSerializer.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/DomSerializer.java
@@ -54,6 +54,7 @@ public class DomSerializer {
 	private static final String FILTER_REF_RELATION = "relation";
 	
 	private static final String FILTER_SUBSTRING = "substring";
+	private static final String FILTER_SUBSTRING_MATCHING_RULE = "matching";
 	private static final String FILTER_SUBSTRING_ANCHOR_START = "anchorStart";
 	private static final String FILTER_SUBSTRING_ANCHOR_END = "anchorEnd";
 	private static final String FILTER_GREATER = "greater";
@@ -65,7 +66,17 @@ public class DomSerializer {
 	
 	private static final String FILTER_PATH = "path";
 	private static final String FILTER_VALUE = "value";
-	
+
+
+	private static final String MATCHING_RULE_DEFAULT = "default";
+	private static final String MATCHING_RULE_STRING_IGNORE_CASE = "stringIgnoreCase";
+	private static final String MATCHING_RULE_POLY_STRING_STRICT = "polyStringStrict";
+	private static final String MATCHING_RULE_POLY_STRING_ORIG = "polyStringOrig";
+	private static final String MATCHING_RULE_POLY_STRING_NORM = "polyStringNorm";
+	private static final String MATCHING_RULE_STRICT_IGNORE_CASE = "strictIgnoreCase";
+	private static final String MATCHING_RULE_ORIG_IGNORE_CASE = "origIgnoreCase";
+	private static final String MATCHING_RULE_NORM_IGNORE_CASE = "normIgnoreCase";
+
 	private Document document;
 	private DocumentBuilder documentBuilder;
 	private JAXBContext jaxbContext;
@@ -77,6 +88,31 @@ public class DomSerializer {
 			document = documentBuilder.newDocument();
 		} catch (ParserConfigurationException e) {
 			throw new IOException(e);
+		}
+	}
+
+	public enum MatchingRuleType
+	{
+		DEFAULT(MATCHING_RULE_DEFAULT),
+		STRING_IGNORE_CASE(MATCHING_RULE_STRING_IGNORE_CASE),
+		POLY_STRING_STRICT(MATCHING_RULE_POLY_STRING_STRICT),
+		POLY_STRING_ORIG(MATCHING_RULE_POLY_STRING_ORIG),
+		POLY_STRING_NORM(MATCHING_RULE_POLY_STRING_NORM),
+		STRICT_IGNORE_CASE(MATCHING_RULE_STRICT_IGNORE_CASE),
+		ORIG_IGNORE_CASE(MATCHING_RULE_ORIG_IGNORE_CASE),
+		NORM_IGNORE_CASE(MATCHING_RULE_NORM_IGNORE_CASE);
+
+		private final String text;
+
+		MatchingRuleType(final String text)
+		{
+			this.text = text;
+		}
+
+		@Override
+		public String toString()
+		{
+			return text;
 		}
 	}
 
@@ -193,6 +229,17 @@ public class DomSerializer {
 		}
 		return substringFilter;
 	}
+
+	public Element appendMatchingRuleElement(Element element, MatchingRuleType matchingRule){
+		element.appendChild(createMatchingRuleElement(matchingRule.toString()));
+		return element;
+	}
+
+	private Element createMatchingRuleElement(String matchingRule){
+		Element matchingRuleElement = document.createElement(FILTER_SUBSTRING_MATCHING_RULE);
+		matchingRuleElement.setTextContent(matchingRule);
+		return matchingRuleElement;
+	}
 	
 	public Element createGreaterFilter(ItemPathType itemPath, Object valueToSearch) {
 		return createPropertyValueFilter(FILTER_GREATER, itemPath, valueToSearch);
@@ -203,7 +250,6 @@ public class DomSerializer {
 	}
 	
 private Element createPropertyValueFilter(String filterType, ItemPathType itemPath, Object valueToSearch){
-	Document document = documentBuilder.newDocument();
 	Element greater = document.createElementNS(SchemaConstants.NS_QUERY, filterType);
 	Element path = document.createElement(FILTER_PATH);
 	path.setTextContent(itemPath.getValue());

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/DomSerializer.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/DomSerializer.java
@@ -208,21 +208,19 @@ private Element createPropertyValueFilter(String filterType, ItemPathType itemPa
 	Element path = document.createElement(FILTER_PATH);
 	path.setTextContent(itemPath.getValue());
 	greater.appendChild(path);
-	
-	Element value = document.createElement(FILTER_VALUE);
+
 	Marshaller marshaller;
 	try {
 		marshaller = jaxbContext.createMarshaller();
-		marshaller.marshal(new JAXBElement(new QName(SchemaConstants.NS_QUERY, "value"), valueToSearch.getClass(), valueToSearch),
-				value);
+		marshaller.marshal(new JAXBElement(new QName(SchemaConstants.NS_QUERY, FILTER_VALUE), valueToSearch.getClass(), valueToSearch),
+				greater);
 		
 	} catch (JAXBException e) {
 		//throw new SchemaException(e);
 		// TODO: how to properly handle??
 		throw new IllegalStateException(e);
 	}
-	
-	greater.appendChild(value);
+
 	return greater;
 }
 	

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/FilterBuilder.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/FilterBuilder.java
@@ -101,6 +101,7 @@ public class FilterBuilder<O extends ObjectType> implements QueryBuilder<O>, Ato
 		return RestJaxbQueryBuilder.create(service, type, this).item(qnames);
 	}
 
+	//TODO: Maybe we can re-structure interfaces to exclude some of the duplicated methods like build and paging
 	@Override
 	public PagingRuleBuilder<O> paging()
 	{

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/FilterBuilder.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/FilterBuilder.java
@@ -4,12 +4,9 @@ import java.util.List;
 
 import javax.xml.namespace.QName;
 
+import com.evolveum.midpoint.client.api.*;
 import org.w3c.dom.Element;
 
-import com.evolveum.midpoint.client.api.AtomicFilterExit;
-import com.evolveum.midpoint.client.api.ConditionEntryBuilder;
-import com.evolveum.midpoint.client.api.QueryBuilder;
-import com.evolveum.midpoint.client.api.SearchService;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 import com.evolveum.prism.xml.ns._public.query_3.FilterClauseType;
 import com.evolveum.prism.xml.ns._public.query_3.NAryLogicalOperatorFilterClauseType;
@@ -104,6 +101,11 @@ public class FilterBuilder<O extends ObjectType> implements QueryBuilder<O>, Ato
 		return RestJaxbQueryBuilder.create(service, type, this).item(qnames);
 	}
 
+	@Override
+	public PagingRuleBuilder<O> paging()
+	{
+		return null;
+	}
 
 	@Override
 	public QueryBuilder<O> and() {

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
@@ -113,7 +113,6 @@ public class RestJaxbQueryBuilder<O extends ObjectType> implements QueryBuilder<
 	@Override
 	public PagingRuleBuilder<O> paging()
 	{
-
 		PagingType pagingType = new PagingType();
 
 		query.setPaging(pagingType);

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
@@ -115,6 +115,10 @@ public class RestJaxbQueryBuilder<O extends ObjectType> implements QueryBuilder<
 	{
 		PagingType pagingType = new PagingType();
 
+		//TODO: Temporary provision to prevent null pointer exception if paging is called before finishQuery()
+		if(query == null) {
+			query = new QueryType();
+		}
 		query.setPaging(pagingType);
 
 		return new RestJaxbQueryBuilder<O>(queryForService, type, query);

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
@@ -34,6 +34,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 import com.evolveum.prism.xml.ns._public.query_3.QueryType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 
+
 /**
  * 
  * @author katkav
@@ -304,28 +305,29 @@ public class RestJaxbQueryBuilder<O extends ObjectType> implements QueryBuilder<
 //		return new RestJaxbQueryBuilder<>(queryForService, type, query, owner);
 	}
 
+	public AtomicFilterExit<O> appendMatchingRuleElement(Element filterClause, DomSerializer.MatchingRuleType matchingRuleType){
+		Element appendedFilter = queryForService.getDomSerializer().appendMatchingRuleElement(filterClause, matchingRuleType);
+		return new RestJaxbQueryBuilder<O>(this, appendedFilter, owner);
+	}
+
 	@Override
 	public AtomicFilterExit<O> matchingOrig() {
-		// TODO Auto-generated method stub
-		return null;
+		return appendMatchingRuleElement(filterClause, DomSerializer.MatchingRuleType.POLY_STRING_ORIG);
 	}
 
 	@Override
 	public AtomicFilterExit<O> matchingNorm() {
-		// TODO Auto-generated method stub
-		return null;
+		return appendMatchingRuleElement(filterClause, DomSerializer.MatchingRuleType.POLY_STRING_NORM);
 	}
 
 	@Override
 	public AtomicFilterExit<O> matchingStrict() {
-		// TODO Auto-generated method stub
-		return null;
+		return appendMatchingRuleElement(filterClause, DomSerializer.MatchingRuleType.POLY_STRING_STRICT);
 	}
 
 	@Override
 	public AtomicFilterExit<O> matchingCaseIgnore() {
-		// TODO Auto-generated method stub
-		return null;
+		return appendMatchingRuleElement(filterClause, DomSerializer.MatchingRuleType.STRING_IGNORE_CASE);
 	}
 
 	@Override

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
@@ -22,13 +22,10 @@ import java.util.List;
 
 import javax.xml.namespace.QName;
 
+import com.evolveum.midpoint.client.api.*;
+import com.evolveum.prism.xml.ns._public.query_3.PagingType;
 import org.w3c.dom.Element;
 
-import com.evolveum.midpoint.client.api.AtomicFilterExit;
-import com.evolveum.midpoint.client.api.ConditionEntryBuilder;
-import com.evolveum.midpoint.client.api.MatchingRuleEntryBuilder;
-import com.evolveum.midpoint.client.api.QueryBuilder;
-import com.evolveum.midpoint.client.api.SearchService;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectReferenceType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 import com.evolveum.prism.xml.ns._public.query_3.QueryType;
@@ -40,7 +37,8 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
  * @author katkav
  *
  */
-public class RestJaxbQueryBuilder<O extends ObjectType> implements QueryBuilder<O>, ConditionEntryBuilder<O>, MatchingRuleEntryBuilder<O> {
+public class RestJaxbQueryBuilder<O extends ObjectType> implements QueryBuilder<O>, ConditionEntryBuilder<O>, MatchingRuleEntryBuilder<O>, PagingRuleBuilder<O>
+{
 
 	private ItemPathType itemPath;
 	private RestJaxbQueryBuilder<O> originalFilter;
@@ -110,6 +108,51 @@ public class RestJaxbQueryBuilder<O extends ObjectType> implements QueryBuilder<
 	@Override
 	public ConditionEntryBuilder<O> item(QName... qnames) {
 		return new RestJaxbQueryBuilder<>(this, queryForService.util().createItemPathType(qnames), owner);
+	}
+
+	@Override
+	public PagingRuleBuilder<O> paging()
+	{
+
+		PagingType pagingType = new PagingType();
+
+		query.setPaging(pagingType);
+
+		return new RestJaxbQueryBuilder<O>(queryForService, type, query);
+	}
+
+	@Override
+	public PagingRuleBuilder<O> orderBy(ItemPathType itemPath)
+	{
+		query.getPaging().setOrderBy(itemPath);
+		return new RestJaxbQueryBuilder<O>(queryForService, type, query);
+	}
+
+	@Override
+	public PagingRuleBuilder<O> groupBy(ItemPathType itemPath)
+	{
+		query.getPaging().setGroupBy(itemPath);
+		return new RestJaxbQueryBuilder<O>(queryForService, type, query);
+	}
+
+	@Override
+	public PagingRuleBuilder<O> offSet(Integer offsetAmount)
+	{
+		query.getPaging().setOffset(offsetAmount);
+		return new RestJaxbQueryBuilder<O>(queryForService, type, query);
+	}
+
+	@Override
+	public PagingRuleBuilder<O> maxSize(Integer maxSize)
+	{
+		query.getPaging().setMaxSize(maxSize);
+		return new RestJaxbQueryBuilder<O>(queryForService, type, query);
+	}
+
+	@Override
+	public QueryBuilder<O> finishPaging()
+	{
+		return new RestJaxbQueryBuilder<O>(queryForService, type, query);
 	}
 
 	@Override

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -212,6 +212,10 @@ public class TestBasic {
 		SearchResult<UserType> result = service.users().search().queryFor(UserType.class)
 				.item(itemPath)
 					.contains("JMORR").matchingNorm()
+				.finishQuery()
+				.paging()
+					.maxSize(1)
+					.finishPaging()
 				
 //			.and()
 //				.item(givenName)
@@ -225,7 +229,6 @@ public class TestBasic {
 //					.eq("jack@example.com")
 					//.and()
 					//.item(new QName()).ref("").and().item(itemPath)
-				.finishQuery()
 				.get();
 		
 		// THEN

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -70,14 +70,14 @@ import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 public class TestBasic {
 	
 	private static Server server;
-	private static final String ENDPOINT_ADDRESS = "http://localhost:8080/midpoint/ws/rest";
-//	private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
+//	private static final String ENDPOINT_ADDRESS = "http://localhost:8080/midpoint/ws/rest";
+	private static final String ENDPOINT_ADDRESS = "http://mpdev1.its.uwo.pri:8080/midpoint/ws/rest";
 	private static final String ADMIN = "administrator";
 	private static final String ADMIN_PASS = "5ecr3t";
 
 	@BeforeClass
 	public void init() throws IOException {
-		startServer();
+//		startServer();
 	}
 	
 	@Test
@@ -211,18 +211,18 @@ public class TestBasic {
 //		cal.setActivation(activation);
 		SearchResult<UserType> result = service.users().search().queryFor(UserType.class)
 				.item(itemPath)
-					.eqPoly("jack")
+					.contains("JMORR").matchingNorm()
 				
-			.and()
-				.item(givenName)
-					.eqPoly("sparrow")
-				
-			.or()
-				.item(activation)
-					.eq(ActivationStatusType.ENABLED)
-			.and()
-				.item(emailAddress)
-					.eq("jack@example.com")
+//			.and()
+//				.item(givenName)
+//					.eqPoly("sparrow")
+//
+//			.or()
+//				.item(activation)
+//					.eq(ActivationStatusType.ENABLED)
+//			.and()
+//				.item(emailAddress)
+//					.eq("jack@example.com")
 					//.and()
 					//.item(new QName()).ref("").and().item(itemPath)
 				.finishQuery()


### PR DESCRIPTION
I added a basic implementation of paging and matching rules.

The matching rule structure was already there - I just filled it out.

For the paging rules, I decided to create the PagingRuleBuilder class and created the "entrance" method in the QueryBuilder interface. The reason I did this is because, currently, the query class member object of RestJaxbQueryBuilder is only initialized when finishQuery() is called and a new RestJaxbQueryBuilder instance is created and returned as a QueryBuilder type. I could have changed this but it may have caused larger changes and implications and I did not want to go ahead and do that without talking about it first since the nature of how the QueryBuilder and FilterBuilder classes work together is a little complex. 

The result of this is that it is possible to call paging() before finishQuery(). I added a provision to create a new query object if this happens, so that a nullPointerException is not thrown, but this new query object with the paging rules will get overwritten when finishQuery() is called. So currently it must be called after finishQuery() to actually work. 

It would be useful I think to try and further detach the filterBuilder from the queryBuilder at some point and avoid having them share interfaces. It would make things less complicated and would make the fluent API more useful to the average user: 

service.users().search()
.queryFor(UserType.class)
   .filter()
       .item() .......
       .item() ......
   .buildFilter()
   .paging()
     .................
   .buildPaging()
.finishQuery().get();

Or something like that.

Let me know what you think! :)