### PR TITLE
Added ObjectCredentialService and executeResetPassword functionality

### DIFF
--- a/midpoint-client-api/pom.xml
+++ b/midpoint-client-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.evolveum.midpoint.client</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.7-SNAPSHOT</version>
+	<version>3.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>midpoint-client-api</artifactId>

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectCredentialService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectCredentialService.java
@@ -6,11 +6,9 @@ import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredential
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
 /**
- * Description
  *
- * @author Jake Morris - jake
- * @version 1.0
- * @since 1.0
+ * @author Jakmor
+ *
  */
 public interface ObjectCredentialService<O extends ObjectType> extends Post<ExecuteCredentialResetResponseType>
 {

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectCredentialService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectCredentialService.java
@@ -1,0 +1,18 @@
+package com.evolveum.midpoint.client.api;
+
+import com.evolveum.midpoint.client.api.verb.Post;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredentialResetRequestType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredentialResetResponseType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
+/**
+ * Description
+ *
+ * @author Jake Morris - jake
+ * @version 1.0
+ * @since 1.0
+ */
+public interface ObjectCredentialService<O extends ObjectType> extends Post<ExecuteCredentialResetResponseType>
+{
+    ObjectCredentialService<O> executeResetPassword(ExecuteCredentialResetRequestType executeCredentialResetRequest);
+}

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectService.java
@@ -32,7 +32,9 @@ import org.apache.commons.lang.Validate;
 public interface ObjectService<O extends ObjectType> extends Get<O>, Delete<O>
 {
     ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException;
-    
+
+    ObjectCredentialService<O> credential();
+
     ValidateGenerateRpcService generate();
 //    ObjectGenerateService<O> modifyGenerate(String path) throws ObjectNotFoundException, AuthenticationException;
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/Service.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/Service.java
@@ -16,6 +16,7 @@
 package com.evolveum.midpoint.client.api;
 
 import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.SecurityPolicyType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ValuePolicyType;
 
@@ -37,5 +38,8 @@ public interface Service {
 	UserType self() throws AuthenticationException;
 	Service impersonate(String oid);
 	Service addHeader(String header, String value);
+
+	ObjectCollectionService<SecurityPolicyType> securityPolicies();
+
 	ServiceUtil util();
 }

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/Service.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/Service.java
@@ -32,7 +32,7 @@ public interface Service {
 
 	RpcService rpc();
 
-	PolicyCollectionService<ValuePolicyType> valuePolicies();
+	ObjectCollectionService<ValuePolicyType> valuePolicies();
 	
 	UserType self() throws AuthenticationException;
 	Service impersonate(String oid);

--- a/midpoint-client-impl-rest-jaxb/pom.xml
+++ b/midpoint-client-impl-rest-jaxb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.evolveum.midpoint.client</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.7-SNAPSHOT</version>
+	<version>3.7.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>midpoint-client-impl-rest-jaxb</artifactId>

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectCredentialService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectCredentialService.java
@@ -2,13 +2,11 @@ package com.evolveum.midpoint.client.impl.restjaxb;
 
 import com.evolveum.midpoint.client.api.ObjectCredentialService;
 import com.evolveum.midpoint.client.api.TaskFuture;
-import com.evolveum.midpoint.client.api.exception.AuthenticationException;
-import com.evolveum.midpoint.client.api.exception.AuthorizationException;
-import com.evolveum.midpoint.client.api.exception.CommonException;
-import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.client.api.exception.*;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredentialResetResponseType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredentialResetRequestType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultType;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
@@ -52,7 +50,7 @@ public class RestJaxbObjectCredentialService<O extends ObjectType>  extends Abst
         Response response = getService().getClient().replacePath(restPath).post(executeCredentialResetRequest);
 
         switch (response.getStatus()) {
-            case 204:
+            case 200:
                 ExecuteCredentialResetResponseType executeCredentialResetResponse = response.readEntity(ExecuteCredentialResetResponseType.class);
 
                 return new RestJaxbCompletedFuture<>(executeCredentialResetResponse);
@@ -65,6 +63,9 @@ public class RestJaxbObjectCredentialService<O extends ObjectType>  extends Abst
                 //TODO: Do we want to return a reference? Might be useful.
             case 404:
                 throw new ObjectNotFoundException(response.getStatusInfo().getReasonPhrase());
+            case 409:
+                OperationResultType operationResultType = response.readEntity(OperationResultType.class);
+                throw new PolicyViolationException(operationResultType.getMessage());
             default:
                 throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
         }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectCredentialService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectCredentialService.java
@@ -12,19 +12,13 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 
 /**
- * Description
  *
- * @author Jake Morris - jake
- * @version 1.0
- * @since 1.0
+ * @author Jakmor
+ *
  */
 public class RestJaxbObjectCredentialService<O extends ObjectType>  extends AbstractObjectWebResource<O> implements ObjectCredentialService<O>
 {
-
     private ExecuteCredentialResetRequestType executeCredentialResetRequest;
-
-    private static final String RESET_METHOD = "resetPassword";
-
 
     public RestJaxbObjectCredentialService(final RestJaxbService service, final Class<O> type, final String oid)
     {

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectCredentialService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectCredentialService.java
@@ -1,0 +1,72 @@
+package com.evolveum.midpoint.client.impl.restjaxb;
+
+import com.evolveum.midpoint.client.api.ObjectCredentialService;
+import com.evolveum.midpoint.client.api.TaskFuture;
+import com.evolveum.midpoint.client.api.exception.AuthenticationException;
+import com.evolveum.midpoint.client.api.exception.AuthorizationException;
+import com.evolveum.midpoint.client.api.exception.CommonException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredentialResetResponseType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredentialResetRequestType;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response;
+
+/**
+ * Description
+ *
+ * @author Jake Morris - jake
+ * @version 1.0
+ * @since 1.0
+ */
+public class RestJaxbObjectCredentialService<O extends ObjectType>  extends AbstractObjectWebResource<O> implements ObjectCredentialService<O>
+{
+
+    private ExecuteCredentialResetRequestType executeCredentialResetRequest;
+
+    private static final String RESET_METHOD = "resetPassword";
+
+
+    public RestJaxbObjectCredentialService(final RestJaxbService service, final Class<O> type, final String oid)
+    {
+        super(service, type, oid);
+    }
+
+    @Override
+    public ObjectCredentialService<O> executeResetPassword(ExecuteCredentialResetRequestType executeCredentialResetRequest)
+    {
+        this.executeCredentialResetRequest = executeCredentialResetRequest;
+
+        return this;
+    }
+
+    @Override
+    public TaskFuture<ExecuteCredentialResetResponseType> apost() throws CommonException
+    {
+        String oid = getOid();
+        String restPath = RestUtil.subUrl(Types.findType(getType()).getRestPath(), oid);
+
+        restPath = restPath.concat("/credential");
+
+        Response response = getService().getClient().replacePath(restPath).post(executeCredentialResetRequest);
+
+        switch (response.getStatus()) {
+            case 204:
+                ExecuteCredentialResetResponseType executeCredentialResetResponse = response.readEntity(ExecuteCredentialResetResponseType.class);
+
+                return new RestJaxbCompletedFuture<>(executeCredentialResetResponse);
+            case 400:
+                throw new BadRequestException(response.getStatusInfo().getReasonPhrase());
+            case 401:
+                throw new AuthenticationException(response.getStatusInfo().getReasonPhrase());
+            case 403:
+                throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
+                //TODO: Do we want to return a reference? Might be useful.
+            case 404:
+                throw new ObjectNotFoundException(response.getStatusInfo().getReasonPhrase());
+            default:
+                throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
+        }
+    }
+}

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectService.java
@@ -15,10 +15,7 @@
  */
 package com.evolveum.midpoint.client.impl.restjaxb;
 
-import com.evolveum.midpoint.client.api.ObjectGenerateService;
-import com.evolveum.midpoint.client.api.ObjectModifyService;
-import com.evolveum.midpoint.client.api.ObjectService;
-import com.evolveum.midpoint.client.api.ValidateGenerateRpcService;
+import com.evolveum.midpoint.client.api.*;
 import com.evolveum.midpoint.client.api.exception.AuthenticationException;
 import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
@@ -51,6 +48,13 @@ public class RestJaxbObjectService<O extends ObjectType> extends AbstractObjectW
 	{
 		return new RestJaxbObjectModifyService<>(getService(), getType(), getOid());
 	}
+
+	@Override
+	public ObjectCredentialService<O> credential(){
+		return new RestJaxbObjectCredentialService<>(getService(),  getType(), getOid());
+	}
+
+
 
 	@Override
 	public ValidateGenerateRpcService generate() {

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -56,6 +56,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
 public class RestJaxbService implements Service {
 	
 	private static final String URL_PREFIX_USERS = "users";
+	private static final String URL_PREFIX_VALUE_POLICIES = "valuePolicies";
 	private static final String IMPERSONATE_HEADER = "Switch-To-Principal";
 
 	
@@ -160,9 +161,10 @@ public class RestJaxbService implements Service {
 	}
 
 	@Override
-	public PolicyCollectionService<ValuePolicyType> valuePolicies() {
-		return new RestJaxbPolicyCollectionService<>(this, URL_PREFIX_USERS, ValuePolicyType.class);
+	public ObjectCollectionService<ValuePolicyType> valuePolicies() {
+		return new RestJaxbObjectCollectionService<>(this, URL_PREFIX_VALUE_POLICIES, ValuePolicyType.class);
 	}
+
 	@Override
 	public ServiceUtil util() {
 		return util;

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -33,6 +33,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import com.evolveum.midpoint.client.api.PolicyCollectionService;
 import com.evolveum.midpoint.client.api.RpcService;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.SecurityPolicyType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ValuePolicyType;
 import com.oracle.jrockit.jfr.UseConstantPool;
 import org.apache.commons.lang.StringUtils;
@@ -58,8 +59,9 @@ public class RestJaxbService implements Service {
 	private static final String URL_PREFIX_USERS = "users";
 	private static final String URL_PREFIX_VALUE_POLICIES = "valuePolicies";
 	private static final String IMPERSONATE_HEADER = "Switch-To-Principal";
+	private static final String URL_PREFIX_SECURITY_POLICIES = "securityPolicies";
 
-	
+
 	private final ServiceUtil util;
 
 	// TODO: jaxb context
@@ -163,6 +165,11 @@ public class RestJaxbService implements Service {
 	@Override
 	public ObjectCollectionService<ValuePolicyType> valuePolicies() {
 		return new RestJaxbObjectCollectionService<>(this, URL_PREFIX_VALUE_POLICIES, ValuePolicyType.class);
+	}
+
+	@Override
+	public ObjectCollectionService<SecurityPolicyType> securityPolicies() {
+		return new RestJaxbObjectCollectionService<>(this, URL_PREFIX_SECURITY_POLICIES, SecurityPolicyType.class);
 	}
 
 	@Override

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbValidateGenerateRpcService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbValidateGenerateRpcService.java
@@ -24,12 +24,10 @@ import javax.ws.rs.core.Response;
 import com.evolveum.midpoint.client.api.PolicyItemDefinitionBuilder;
 import com.evolveum.midpoint.client.api.TaskFuture;
 import com.evolveum.midpoint.client.api.ValidateGenerateRpcService;
-import com.evolveum.midpoint.client.api.exception.AuthenticationException;
-import com.evolveum.midpoint.client.api.exception.AuthorizationException;
-import com.evolveum.midpoint.client.api.exception.CommonException;
-import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.client.api.exception.*;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultType;
 
 /**
  * 
@@ -63,7 +61,6 @@ public class RestJaxbValidateGenerateRpcService implements ValidateGenerateRpcSe
 		switch (response.getStatus()) {
         case 200:
             PolicyItemsDefinitionType itemsDefinitionType = response.readEntity(PolicyItemsDefinitionType.class);
-            
             return new RestJaxbCompletedFuture<PolicyItemsDefinitionType>(itemsDefinitionType);
         case 400:
             throw new BadRequestException(response.getStatusInfo().getReasonPhrase());
@@ -71,9 +68,11 @@ public class RestJaxbValidateGenerateRpcService implements ValidateGenerateRpcSe
             throw new AuthenticationException(response.getStatusInfo().getReasonPhrase());
         case 403:
             throw new AuthorizationException(response.getStatusInfo().getReasonPhrase());
-            //TODO: Do we want to return a reference? Might be useful.
         case 404:
             throw new ObjectNotFoundException(response.getStatusInfo().getReasonPhrase());
+		case 409:
+			OperationResultType operationResultType = response.readEntity(OperationResultType.class);
+	        throw new PolicyViolationException(operationResultType.getMessage());
         default:
             throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
     }

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/Types.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/Types.java
@@ -24,6 +24,7 @@ import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredential
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectListType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.SecurityPolicyType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ValuePolicyType;
 import com.evolveum.prism.xml.ns._public.query_3.QueryType;
@@ -41,6 +42,7 @@ public enum Types {
 	POLICY_ITEMS_DEFINITION(PolicyItemsDefinitionType.class, new QName(SchemaConstants.NS_API_TYPES, "PolicyItemsDefinitionType"), new QName(SchemaConstants.NS_API_TYPES, "policyItemsDefinition"), ""),
 	OBJECT_MODIFICATION_TYPE(ObjectModificationType.class, new QName(SchemaConstants.NS_API_TYPES, "ObjectModificationType"), new QName(SchemaConstants.NS_API_TYPES, "objectModification"), ""),
 	VALUE_POLICIES(ValuePolicyType.class, new QName(SchemaConstants.NS_COMMON, "ValuePolicyType"), new QName(SchemaConstants.NS_COMMON, "valuePolicy"), "valuePolicies"),
+	SECURITY_POLICIES(SecurityPolicyType.class, new QName(SchemaConstants.NS_COMMON, "SecurityPolicyType"), new QName(SchemaConstants.NS_COMMON, "securityPolicy"), "securityPolicies"),
 	EXECUTE_CREDENTIAL_RESET_REQUEST(ExecuteCredentialResetRequestType.class, new QName(SchemaConstants.NS_API_TYPES, "ExecuteCredentialResetRequestType"), new QName(SchemaConstants.NS_API_TYPES, "executeCredentialResetRequest"), "");
 
 	

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/Types.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/Types.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import javax.jws.Oneway;
 import javax.xml.namespace.QName;
 
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredentialResetRequestType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectListType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
@@ -39,8 +40,9 @@ public enum Types {
 	OBJECT_LIST_TYPE(ObjectListType.class, new QName(SchemaConstants.NS_API_TYPES, "ObjectListType"), new QName(SchemaConstants.NS_API_TYPES, "objectList"), ""),
 	POLICY_ITEMS_DEFINITION(PolicyItemsDefinitionType.class, new QName(SchemaConstants.NS_API_TYPES, "PolicyItemsDefinitionType"), new QName(SchemaConstants.NS_API_TYPES, "policyItemsDefinition"), ""),
 	OBJECT_MODIFICATION_TYPE(ObjectModificationType.class, new QName(SchemaConstants.NS_API_TYPES, "ObjectModificationType"), new QName(SchemaConstants.NS_API_TYPES, "objectModification"), ""),
-	VALUE_POLICIES(ValuePolicyType.class, new QName(SchemaConstants.NS_COMMON, "ValuePolicyType"), new QName(SchemaConstants.NS_COMMON, "valuePolicy"), "valuePolicies");
-	
+	VALUE_POLICIES(ValuePolicyType.class, new QName(SchemaConstants.NS_COMMON, "ValuePolicyType"), new QName(SchemaConstants.NS_COMMON, "valuePolicy"), "valuePolicies"),
+	EXECUTE_CREDENTIAL_RESET_REQUEST(ExecuteCredentialResetRequestType.class, new QName(SchemaConstants.NS_API_TYPES, "ExecuteCredentialResetRequestType"), new QName(SchemaConstants.NS_API_TYPES, "executeCredentialResetRequest"), "");
+
 	
 	private Class<?> clazz;
 	/**

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -322,6 +322,7 @@ public class TestBasic {
 	public void test202policyGenerate() throws Exception
 	{
 		Service service = getService();
+
 		PolicyItemsDefinitionType policyItemsDefinition = service.rpc().generate()
 				.items()
 					.item()

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -35,6 +35,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
 import com.evolveum.midpoint.client.api.ServiceUtil;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ExecuteCredentialResetRequestType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
@@ -404,6 +405,24 @@ public class TestBasic {
 					.path("credentials/password/value")
 				.build()
 			.post();
+	}
+
+	@Test
+	public void test213UserCredentialsReset() throws Exception{
+		// SETUP
+		Service service = getService();
+
+		ExecuteCredentialResetRequestType executeCredentialResetRequest = new ExecuteCredentialResetRequestType();
+
+		executeCredentialResetRequest.setResetMethod("passwordReset");
+		executeCredentialResetRequest.setUserEntry("P4ssw0rd");
+
+		// WHEN
+		try{
+			service.users().oid("1bae776f-4939-4071-92e2-8efd5bd57799").credential().executeResetPassword(executeCredentialResetRequest).post();
+		}catch(ObjectNotFoundException e){
+			fail("Cannot delete user, user not found");
+		}
 	}
 
 	@Test

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -128,6 +128,17 @@ public class TestBasic {
 	}
 
 	@Test
+	public void test012SecurityPolicyGet() throws Exception {
+		Service service = getService();
+
+		// WHEN
+		SecurityPolicyType securityPolicyType = service.securityPolicies().oid("westernu-0002-0000-0000-000000000001").get();
+
+		// THEN
+		assertNotNull("null security policy", securityPolicyType);
+	}
+
+	@Test
 	public void test003UserGetNotExist() throws Exception {
 		Service service = getService();
 

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -81,45 +81,56 @@ public class TestBasic {
 	@Test
 	public void test001UserAdd() throws Exception {
 		Service service = getService();
-		
+
 		UserType userBefore = new UserType();
 		userBefore.setName(service.util().createPoly("foo"));
 		userBefore.setOid("123");
-		
+
 		ActivationType activation = new ActivationType();
-		
+
 		XMLGregorianCalendar validFrom = service.util().asXMLGregorianCalendar(new Date());
 		activation.setValidFrom(validFrom);
 		userBefore.setActivation(activation);
-		
+
 		// WHEN
 		ObjectReference<UserType> ref = service.users().add(userBefore).post();
-		
+
 		// THEN
 		assertNotNull("Null oid", ref.getOid());
-		
+
 		UserType userAfter = ref.get();
 		Asserts.assertPoly(service, "Wrong name", "foo", userAfter.getName());
-		
+
 		// TODO: get user, compare
-		
+
 	}
-	
+
 	@Test
 	public void test002UserGet() throws Exception {
 		Service service = getService();
-		
+
 		// WHEN
 		UserType userType = service.users().oid("123").get();
-		
+
 		// THEN
 		assertNotNull("null user", userType);
 	}
-	
+
+	@Test
+	public void test011ValuePolicyGet() throws Exception {
+		Service service = getService();
+
+		// WHEN
+		ValuePolicyType valuePolicyType = service.valuePolicies().oid("00000000-0000-0000-0000-000000000003").get();
+
+		// THEN
+		assertNotNull("null value policy", valuePolicyType);
+	}
+
 	@Test
 	public void test003UserGetNotExist() throws Exception {
 		Service service = getService();
-		
+
 		// WHEN
 		try {
 			service.users().oid("999").get();
@@ -182,7 +193,7 @@ public class TestBasic {
 //			fail("Cannot delete user, user not found");
 //		}
 //	}
-	
+
 	@Test
 	public void test010UserSearch() throws Exception {
 		Service service = getService();
@@ -210,7 +221,7 @@ public class TestBasic {
 				.maxSize(1000)
 				.finishPaging()
 				.get();
-		
+
 		// THEN
 		assertEquals(result.size(), 0);
 	}
@@ -219,13 +230,13 @@ public class TestBasic {
 	public void test100challengeRepsonse() throws Exception {
 		RestJaxbService service = (RestJaxbService) getService(ADMIN, "", AuthenticationType.SECQ);
 
-		try { 
+		try {
 			service.users().oid("123").get();
 			fail("unexpected success. should fail because of authentication");
 		} catch (AuthenticationException ex) {
-			//this is expected.. 
+			//this is expected..
 		}
-		
+
 		SecurityQuestionChallenge challenge = (SecurityQuestionChallenge) service.getAuthenticationManager().getChallenge();
 		for (SecurityQuestionAnswer qa : challenge.getAnswer()) {
 			if ("id1".equals(qa.getQid())) {
@@ -235,19 +246,19 @@ public class TestBasic {
 			}
 
 		}
-		
+
 		service = (RestJaxbService) getService(ADMIN, challenge.getAnswer());
-		
-		try { 
+
+		try {
 			service.users().oid("123").get();
-			
+
 		} catch (AuthenticationException ex) {
 			fail("should authenticate user successfully");
 		}
-		
-		
+
+
 	}
-	
+
 	@Test
 	public void test200fullChallengeRepsonse() throws Exception {
 		RestJaxbService service = (RestJaxbService) getService(null, null, null);
@@ -287,11 +298,11 @@ public class TestBasic {
 						.path("givenName")
 					.build()
 				.post();
-		
+
 		assertEquals(1, policyItemsDefinition.getPolicyItemDefinition().size());
 		PolicyItemDefinitionType policyitemDefinition = policyItemsDefinition.getPolicyItemDefinition().iterator().next();
 		assertNotNull(policyitemDefinition.getValue());
-		
+
 		UserType user = service.users().oid("876").get();
 		assertNotNull(service.util().getOrig(user.getGivenName()));
 	}
@@ -309,9 +320,9 @@ public class TestBasic {
 		assertEquals(1, policyItemsDefinition.getPolicyItemDefinition().size());
 		PolicyItemDefinitionType policyitemDefinition = policyItemsDefinition.getPolicyItemDefinition().iterator().next();
 		assertNotNull(policyitemDefinition.getValue());
-		
+
 	}
-	
+
 	public void test012Self() throws Exception {
 		Service service = getService();
 
@@ -326,7 +337,7 @@ public class TestBasic {
 
 		assertEquals(service.util().getOrig(loggedInUser.getName()), ADMIN);
 	}
-	
+
 	@Test
 	public void test203rpcValidate() throws Exception {
 		Service service = getService();
@@ -337,11 +348,11 @@ public class TestBasic {
 						.value("asdasd")
 					.build()
 				.post();
-		
+
 		boolean allMatch = defs.getPolicyItemDefinition().stream().allMatch(def -> def.getResult().getStatus() == OperationResultStatusType.SUCCESS);
 		assertEquals(allMatch, true);
 	}
-	
+
 	@Test
 	public void test204rpcValidate() throws Exception {
 		Service service = getService();
@@ -351,7 +362,7 @@ public class TestBasic {
 					.build()
 				.post();
 	}
-	
+
 	@Test
 	public void test205rpcValidate() throws Exception {
 		Service service = getService();
@@ -367,7 +378,7 @@ public class TestBasic {
 				.build()
 			.post();
 	}
-	
+
 	@Test
 	public void test210rpcGenerate() throws Exception {
 		Service service = getService();
@@ -379,7 +390,7 @@ public class TestBasic {
 					.build()
 				.post();
 	}
-	
+
 	@Test
 	public void test211rpcGenerate() throws Exception {
 		Service service = getService();
@@ -390,7 +401,7 @@ public class TestBasic {
 				.build()
 			.post();
 	}
-	
+
 	@Test
 	public void test212rpcGenerate() throws Exception {
 		Service service = getService();
@@ -419,7 +430,7 @@ public class TestBasic {
 
 		// WHEN
 		try{
-			service.users().oid("1bae776f-4939-4071-92e2-8efd5bd57799").credential().executeResetPassword(executeCredentialResetRequest).post();
+			service.users().oid("").credential().executeResetPassword(executeCredentialResetRequest).post();
 		}catch(ObjectNotFoundException e){
 			fail("Cannot delete user, user not found");
 		}
@@ -454,53 +465,53 @@ public class TestBasic {
 			fail("Cannot delete user, user not found");
 		}
 	}
-	
 
 
 
-	private Service getService() throws IOException {		
+
+	private Service getService() throws IOException {
 		return getService(ADMIN, ADMIN_PASS, AuthenticationType.BASIC);
-		
+
 	}
-	
+
 	private Service getService(String username, List<SecurityQuestionAnswer> answer) throws IOException {
-	
+
 	RestJaxbServiceBuilder serviceBuilder = new RestJaxbServiceBuilder();
 	serviceBuilder.authentication(AuthenticationType.SECQ).username(username).authenticationChallenge(answer).url(ENDPOINT_ADDRESS);
 	RestJaxbService service = serviceBuilder.build();
 	WebClient client = service.getClient();
 	WebClient.getConfig(client).getRequestContext().put(LocalConduit.DIRECT_DISPATCH, Boolean.TRUE);
-	
+
 	return service;
-	
+
 }
 
 	private Service getService(String username, String password, AuthenticationType authenticationType) throws IOException {
-		
+
 		RestJaxbServiceBuilder serviceBuilder = new RestJaxbServiceBuilder();
 		serviceBuilder.authentication(authenticationType).username(username).password(password).url(ENDPOINT_ADDRESS);
 		RestJaxbService service = serviceBuilder.build();
 		WebClient client = service.getClient();
 		WebClient.getConfig(client).getRequestContext().put(LocalConduit.DIRECT_DISPATCH, Boolean.TRUE);
-		
+
 		return service;
-		
+
 	}
-	
+
 	private void startServer() throws IOException {
 		JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
 	     sf.setResourceClasses(MidpointMockRestService.class);
-	     
+
 	     sf.setProviders(Arrays.asList(new JaxbXmlProvider<>(createJaxbContext()), new AuthenticationProvider()));
-	         
+
 	     sf.setResourceProvider(MidpointMockRestService.class,
 	                            new SingletonResourceProvider(new MidpointMockRestService(), true));
 	     sf.setAddress(ENDPOINT_ADDRESS);
-	 
-	     
+
+
 	     server = sf.create();
 	}
-	
+
 	private JAXBContext createJaxbContext() throws IOException {
 		try {
 		JAXBContext jaxbCtx = JAXBContext.newInstance("com.evolveum.midpoint.xml.ns._public.common.api_types_3:"
@@ -525,7 +536,7 @@ public class TestBasic {
 		} catch (JAXBException e) {
 			throw new IOException(e);
 		}
-		
+
 	}
 	
 

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -355,8 +355,8 @@ public class TestBasic {
 		PolicyItemsDefinitionType defs = service.rpc().validate()
 				.items()
 					.item()
-						.policy("00000000-0000-0000-0000-p00000000001")
-						.value("asdasd")
+						.policy("00000000-0000-0000-0000-000000000003")
+						.value("as")
 					.build()
 				.post();
 
@@ -437,11 +437,11 @@ public class TestBasic {
 		ExecuteCredentialResetRequestType executeCredentialResetRequest = new ExecuteCredentialResetRequestType();
 
 		executeCredentialResetRequest.setResetMethod("passwordReset");
-		executeCredentialResetRequest.setUserEntry("P4ssw0rd");
+		executeCredentialResetRequest.setUserEntry("secret");
 
 		// WHEN
 		try{
-			service.users().oid("").credential().executeResetPassword(executeCredentialResetRequest).post();
+			service.users().oid("1bae776f-4939-4071-92e2-8efd5bd57799").credential().executeResetPassword(executeCredentialResetRequest).post();
 		}catch(ObjectNotFoundException e){
 			fail("Cannot delete user, user not found");
 		}
@@ -549,6 +549,6 @@ public class TestBasic {
 		}
 
 	}
-	
+
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.evolveum.midpoint.client</groupId>
     <artifactId>parent</artifactId>
-    <version>3.7-SNAPSHOT</version>
+    <version>3.7.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -33,7 +33,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.source.version>1.8</project.source.version>
-        <midpoint.version>3.7-SNAPSHOT</midpoint.version>
+        <midpoint.version>3.7.1-SNAPSHOT</midpoint.version>
         <testng.version>6.8.8</testng.version>
     </properties>
 


### PR DESCRIPTION
Added a basic implementation of reset password. The dependencies have been updated to 3.7.1 to support this. 

The usage looks like this:

service.users().oid().credential().executeResetPassword(executeResetCredentialRequest).post()

An example can be found with the tests. 

I also added support for 409 status codes for both this and validate/generate and security/value policies. (Not directly related to this feature, but something we needed to add quickly )


