### PR TITLE
Feature/add validate message extraction utility

### DIFF
--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbValidateGenerateRpcService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbValidateGenerateRpcService.java
@@ -72,7 +72,7 @@ public class RestJaxbValidateGenerateRpcService implements ValidateGenerateRpcSe
             throw new ObjectNotFoundException(response.getStatusInfo().getReasonPhrase());
 		case 409:
 			OperationResultType operationResultType = response.readEntity(OperationResultType.class);
-	        throw new PolicyViolationException(operationResultType.getMessage());
+	        throw new PolicyViolationException(RestUtil.getFailedValidationMessage(operationResultType));
         default:
             throw new UnsupportedOperationException("Implement other status codes, unsupported return status: " + response.getStatus());
     }


### PR DESCRIPTION
I'm not sure if the is the best way to do this, but we needed a way to parse the messages returned from validate calls. Right now midPoint returns a PolicyItemsDefinitionType object on a successful validation call but returns an OperationResultType object when it fails along with a 409 code. This is troublesome to manage. I thought about putting the OperationResultType object inside of PolicyItemDefinitionType object, and that inside of a PolicyItemsDefinitionType to match the output of successful calls, but, for now, I have just created a custom exception and extracted the messaging from the returned OperationResultType as this solution reflects what midPoint is actually returning.

I feel like returning 409 on failed validations is a confusing use of the error code. The request itself is still successful even if the validation operation fails - there is no conflict with the request. I feel that it might make more sense to return a PolicyItemsDefinition type on both successful and failed validations and then write a utility to determine the outcome instead of using a status code. 

That being said, I realize that there may be a reason for this usage that I am not aware of. 

Let me know what you think!
