### PR TITLE
Feature -  ability to handle Midpoint's query language

### DIFF
--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/query/QueryExit.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/query/QueryExit.java
@@ -24,6 +24,7 @@ import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.client.api.exception.SchemaException;
 import com.evolveum.midpoint.client.api.verb.Get;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.prism.xml.ns._public.query_3.QueryType;
 
 /**
  *
@@ -40,6 +41,8 @@ public interface QueryExit<O extends ObjectType> extends Get<SearchResult<O>> {
 	 * Returns search service with the query set.
 	 */
 	SearchService<O> build();
+
+    SearchService<O> build(QueryType query);
 
 //	public ConditionEntry<O> item(ItemPathType itemPath);
 //	public ConditionEntry<O> item(QName... qnames);

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/FilterBuilder.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/FilterBuilder.java
@@ -117,6 +117,11 @@ public class FilterBuilder<O extends ObjectType> implements FilterEntryOrEmpty<O
 
 	}
 
+    @Override
+    public SearchService<O> build(QueryType query) {
+        return new RestJaxbSearchService<>(service, type, query);
+    }
+
 
 	@Override
 	public ConditionEntry<O> item(ItemPathType itemPath) {

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbQueryBuilder.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import javax.xml.namespace.QName;
 
+import com.evolveum.prism.xml.ns._public.query_3.QueryType;
+
 import org.w3c.dom.Element;
 
 import com.evolveum.midpoint.client.api.SearchService;
@@ -102,8 +104,12 @@ public class RestJaxbQueryBuilder<O extends ObjectType> implements ConditionEntr
 //		return new RestJaxbSearchService<O>(queryForService, type, query);
 	}
 
+    @Override
+    public SearchService<O> build(QueryType query) {
+        return null;
+    }
 
-	@Override
+    @Override
 	public MatchingRuleEntry<O> eq(Object... values) {
 		Element equal = queryForService.getDomSerializer().createEqualFilter(itemPath, Arrays.asList(values));
 		return new RestJaxbQueryBuilder<O>(this, equal, owner);

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -22,6 +22,9 @@ import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.client.api.exception.PolicyViolationException;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+import com.evolveum.prism.xml.ns._public.query_3.PagingType;
+import com.evolveum.prism.xml.ns._public.query_3.QueryType;
+import com.evolveum.prism.xml.ns._public.query_3.SearchFilterType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 
 import org.apache.cxf.endpoint.Server;
@@ -203,6 +206,30 @@ public class TestBasic extends AbstractTest {
         // THEN
         assertEquals(result.size(), 0);
     }
+
+    @Test
+    public void test014UserFilterQuerySearchMock() throws Exception {
+        Service service = getService();
+
+        QueryType query = new QueryType();
+        PagingType pagingType = new PagingType();
+        pagingType.setMaxSize(1);
+        pagingType.setOffset(0);
+        query.setPaging(pagingType);
+        SearchFilterType searchFilterType = new SearchFilterType();
+        searchFilterType.setText("name contains \"a\" or familyName startsWith \"X\"");
+        query.setFilter(searchFilterType);
+
+        SearchResult<UserType> result = service.users().search()
+                .queryFor(UserType.class)
+                .build(query)
+                .options()
+                .resolveNames()
+                .get();
+
+        assertEquals(result.size(), 0);
+    }
+
 
     @Test
     public void test011ValuePolicyGet() throws Exception {

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestIntegrationBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestIntegrationBasic.java
@@ -20,6 +20,9 @@ import com.evolveum.midpoint.client.api.exception.AuthenticationException;
 import com.evolveum.midpoint.client.api.exception.SchemaException;
 import com.evolveum.midpoint.client.api.query.AtomicFilterExit;
 import com.evolveum.midpoint.client.api.query.ConditionEntry;
+import com.evolveum.prism.xml.ns._public.query_3.PagingType;
+import com.evolveum.prism.xml.ns._public.query_3.QueryType;
+import com.evolveum.prism.xml.ns._public.query_3.SearchFilterType;
 import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
 
 import org.apache.commons.lang3.StringUtils;
@@ -379,6 +382,30 @@ public class TestIntegrationBasic extends AbstractTest {
         }
         assertEquals(users.size(), 10);
     }
+
+    @Test
+    public void test610searchUserFilterQuery() throws Exception {
+        Service service = getService();
+
+        QueryType query = new QueryType();
+        PagingType pagingType = new PagingType();
+        pagingType.setMaxSize(1);
+        pagingType.setOffset(0);
+        query.setPaging(pagingType);
+        SearchFilterType searchFilterType = new SearchFilterType();
+        searchFilterType.setText("name contains \"admin\" or familyName startsWith \"X\"");
+        query.setFilter(searchFilterType);
+
+        SearchResult<UserType> users = service.users().search()
+                .queryFor(UserType.class)
+                .build(query)
+                .options()
+                .resolveNames()
+                .get();
+
+        assertEquals(users.size(), 1);
+    }
+
 
     @Test
     public void test700addSecurityPolicy() throws Exception {


### PR DESCRIPTION
Modification was made to support handeling of **Midpoints query language**  querys.

For my usecase i need midpoint-client-java to be able to accept filter in a form of Midpoint's query language. For example: 

"text": "extension/ssn contains "this" or familyName startsWith "M"". 

I looked at the provided client lib source code and i didnt find a way to do it with existing functionalities so i decided to modify source code by overloading build method in FilterBuilder with one parameter of type QueryType. In that function i just call RestJaxbSearchService constructor with my query parameter passed to it. Idea is to be able to do something like this 

midpointClient.users().search().queryFor(UserType.class).build(query).options().resolveNames().get(). 

I hope that i didnt skipped or overlooked something in my code analysis and implemented already supported feature. Thank you all and best regards