### PR TITLE
fix impersonate: Prevent impersonate OID duplication

### DIFF
--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/Service.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/Service.java
@@ -15,7 +15,6 @@
  */
 package com.evolveum.midpoint.client.api;
 
-import com.evolveum.midpoint.client.api.exception.AuthenticationException;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 import com.evolveum.midpoint.client.api.scripting.ScriptingUtil;
 
@@ -41,7 +40,11 @@ public interface Service {
 
 	Service impersonate(String oid);
 
+    Service removeImpersonate();
+
 	Service addHeader(String header, String value);
+
+    Service removeHeader(String header);
 
 	ObjectCollectionService<SecurityPolicyType> securityPolicies();
 

--- a/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismService.java
+++ b/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismService.java
@@ -268,7 +268,17 @@ public class RestPrismService implements Service {
     }
 
     @Override
+    public Service removeImpersonate() {
+        return null;
+    }
+
+    @Override
     public Service addHeader(String header, String value) {
+        return null;
+    }
+
+    @Override
+    public Service removeHeader(String header) {
         return null;
     }
 

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbService.java
@@ -52,7 +52,7 @@ public class RestJaxbService implements Service {
     private final ServiceUtil util;
     private final ScriptingUtil scriptingUtil;
 
-    private WebClient client;
+    private final WebClient client;
     private DomSerializer domSerializer;
     private JAXBContext jaxbContext;
     private AuthenticationManager<?> authenticationManager;
@@ -121,15 +121,40 @@ public class RestJaxbService implements Service {
 
     }
 
+    /**
+     * Add Switch-To-Principal HTTP header with only one value.
+     * If this method is executed multiple times than latest oid value will be used.
+     * @return this Service instance
+     */
     @Override
     public Service impersonate(String oid) {
-        client.header(IMPERSONATE_HEADER, oid);
+        client.replaceHeader(IMPERSONATE_HEADER, oid);
+        return this;
+    }
+
+    /**
+     * Remove Switch-To-Principal HTTP header.
+     * @return this Service instance
+     */
+    @Override
+    public Service removeImpersonate() {
+        client.replaceHeader(IMPERSONATE_HEADER, null);
         return this;
     }
 
     @Override
     public Service addHeader(String header, String value) {
         client.header(header, value);
+        return this;
+    }
+
+    /**
+     * Remove any HTTP header.
+     * @return this Service instance
+     */
+    @Override
+    public Service removeHeader(String header) {
+        client.replaceHeader(header, null);
         return this;
     }
 

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/TestBasic.java
@@ -17,9 +17,7 @@ package com.evolveum.midpoint.client.impl.restjaxb;
 
 import com.evolveum.midpoint.client.api.*;
 import com.evolveum.midpoint.client.api.exception.AuthenticationException;
-import com.evolveum.midpoint.client.api.exception.CommonException;
 import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.client.api.exception.PolicyViolationException;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.PolicyItemsDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 import com.evolveum.prism.xml.ns._public.query_3.PagingType;
@@ -34,7 +32,6 @@ import org.testng.annotations.Test;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
@@ -337,6 +334,91 @@ public class TestBasic extends AbstractTest {
         }
 
         assertEquals(service.util().getOrig(loggedInUser.getName()), ADMIN);
+    }
+
+    @Test
+    public void test013ImpersonateWith_OID1_Self() throws Exception {
+        Service service = getService();
+        final String IMPERSONATE_OID1 = "44af349b-5a0c-4f3a-9fe9-2f64d9390ed3";
+        final String IMPERSONATE_OID2 = "876";
+
+        UserType loggedInUser = null;
+
+        try {
+            loggedInUser = service.impersonate(IMPERSONATE_OID2).impersonate(IMPERSONATE_OID1).self();
+
+        } catch (AuthenticationException ex) {
+            fail("should authenticate user successfully");
+        }
+
+        assertEquals(service.util().getOrig(loggedInUser.getName()), "impersonate");
+    }
+
+    @Test
+    public void test013ImpersonateWith_OID2_Self() throws Exception {
+        Service service = getService();
+        final String IMPERSONATE_OID1 = "44af349b-5a0c-4f3a-9fe9-2f64d9390ed3";
+        final String IMPERSONATE_OID2 = "876";
+
+        UserType loggedInUser = null;
+
+        try {
+            loggedInUser = service.impersonate(IMPERSONATE_OID1).impersonate(IMPERSONATE_OID2).self();
+
+        } catch (AuthenticationException ex) {
+            fail("should authenticate user successfully");
+        }
+
+        assertEquals(service.util().getOrig(loggedInUser.getName()), "jack");
+    }
+
+    @Test
+    public void test013HeaderSetupSelf() throws Exception {
+        Service service = getService();
+        final String IMPERSONATE_OID1 = "44af349b-5a0c-4f3a-9fe9-2f64d9390ed3";
+        final String IMPERSONATE_OID2 = "876";
+        final String IMPERSONATE_OID3 = "unknown";
+
+        UserType loggedInUser = null;
+
+        try {
+            loggedInUser = service
+                    .addHeader("Switch-To-Principal", IMPERSONATE_OID1)
+                    .addHeader("Switch-To-Principal", IMPERSONATE_OID2)
+                    .addHeader("Switch-To-Principal", IMPERSONATE_OID3)
+                    .removeHeader("Switch-To-Principal")
+                    .self();
+
+        } catch (AuthenticationException ex) {
+            fail("should authenticate user successfully");
+        }
+
+        assertEquals(service.util().getOrig(loggedInUser.getName()), ADMIN);
+    }
+
+    @Test
+    public void test013ImpersonateWith_Admin_Self() throws Exception {
+        Service service = getService();
+        final String IMPERSONATE_OID1 = "876";
+        final String IMPERSONATE_OID2 = "44af349b-5a0c-4f3a-9fe9-2f64d9390ed3";
+
+        UserType loggedInUser = null;
+
+        try {
+            loggedInUser = service.impersonate(IMPERSONATE_OID1).impersonate(IMPERSONATE_OID2).removeImpersonate().self();
+
+        } catch (AuthenticationException ex) {
+            fail("should authenticate user successfully");
+        }
+
+        assertEquals(service.util().getOrig(loggedInUser.getName()), ADMIN);
+    }
+
+    @Test(expectedExceptions = AuthenticationException.class)
+    public void test016ImpersonateSelfWithUnknownOIDMustFail() throws Exception {
+        Service service = getService();
+        final String IMPERSONATE_OID = "unknown";
+        service.impersonate(IMPERSONATE_OID).self();
     }
 
     @Test

--- a/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
+++ b/midpoint-client-impl-rest-jaxb/src/test/java/com/evolveum/midpoint/client/impl/restjaxb/service/MidpointMockRestService.java
@@ -495,12 +495,15 @@ List<PolicyItemDefinitionType> policyItemDefinitionTypes = object.getPolicyItemD
 		UserType userType;
 
 		if(null != impersonateOid){
-			userType = (UserType) userMap.get(impersonateOid);
-		}else
-		{
+            userType = userMap.get(impersonateOid);
+            if (userType == null) {
+                return RestMockServiceUtil.createResponse(Status.UNAUTHORIZED, result);
+            }
+		} else {
 			userType = new UserType();
 			userType.setName(util.createPoly("administrator"));
 		}
+
 		return RestMockServiceUtil.createResponse(Status.OK, userType, result);
 	}
 


### PR DESCRIPTION
Hello Evolveum Team,

**issue:**

Prevent impersonate OID duplication in Switch-To-Principal when impersonate method is called multiple times using singleton instance in SpringBoot.

```
@Qualifier("midpointService")
private final Service midpointClient;
...
 midpointClient.impersonate("OID from external system located in http header field X-User-ID"); // system can send any OID
...
```
.....

**details:**

The problem is that midpointClient instance is remembering the previous OID value of impersonated user, and there is not way to clear it before making the call with new OID. See image below for details.

**wireshark log**

![image](https://github.com/user-attachments/assets/b4b66bfb-bb1a-42b6-9066-f3ea8b3fb2e3)
