### PR TITLE
Feature - support for HTTP PATCH in client's Prism implementation module

### DIFF
--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/AbstractObjectWebResource.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/AbstractObjectWebResource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017-2025 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.evolveum.midpoint.client.api;
+
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+
+/**
+ * @author Z14tk0
+ *
+ */
+public abstract class AbstractObjectWebResource<O extends ObjectType> extends AbstractWebResource {
+
+    private final Class<O> type;
+    private final String oid;
+
+    public AbstractObjectWebResource(final Service service, final Class<O> type, final String oid) {
+        super(service);
+        this.type = type;
+        this.oid = oid;
+    }
+
+    protected Class<O> getType() {
+        return type;
+    }
+
+    protected String getOid() {
+        return oid;
+    }
+}

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/AbstractWebResource.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/AbstractWebResource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017-2025 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.evolveum.midpoint.client.api;
+
+/**
+ * @author Z14tk0
+ *
+ */
+public abstract class AbstractWebResource {
+
+    private final Service service;
+
+	public AbstractWebResource(final Service service) {
+		super();
+		this.service = service;
+	}
+
+	protected Service getService() {
+		return service;
+	}
+
+}

--- a/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
+++ b/midpoint-client-api/src/main/java/com/evolveum/midpoint/client/api/ObjectModifyService.java
@@ -15,10 +15,10 @@
  */
 package com.evolveum.midpoint.client.api;
 
-import java.util.List;
+import java.io.InputStream;
 import java.util.Map;
 
-import com.evolveum.midpoint.client.api.exception.CommonException;
+import com.evolveum.midpoint.client.api.exception.SchemaException;
 import com.evolveum.midpoint.client.api.verb.Post;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
@@ -32,6 +32,7 @@ public interface ObjectModifyService <O extends ObjectType> extends Post<ObjectR
     ObjectModifyService<O> replace(Map<String, Object> modifications);
     ObjectModifyService<O> delete(String path, Object value);
     ObjectModifyService<O> delete(Map<String, Object> modifications);
+    ObjectModifyService<O> setModifications(InputStream inputStream) throws SchemaException;
 
     ExecuteOptionSupport.WithPost<ObjectReference<O>> options();
 

--- a/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismObjectModifyService.java
+++ b/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismObjectModifyService.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2017-2025 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.evolveum.midpoint.client.impl.prism;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.evolveum.midpoint.client.api.*;
+import com.evolveum.midpoint.client.api.exception.CommonException;
+import com.evolveum.midpoint.client.api.exception.ObjectAlreadyExistsException;
+import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.client.api.exception.SchemaException;
+import com.evolveum.midpoint.schema.constants.ObjectTypes;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
+import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
+
+/**
+ * @author Z14tk0
+ */
+public class RestPrismObjectModifyService<O extends ObjectType> implements ObjectModifyService<O> {
+
+    private List<ItemDeltaType> modifications;
+    private final RestPrismService service;
+    private final ObjectTypes type;
+    private List<String> options;
+    private String oid;
+
+    @Override
+    public ExecuteOptionSupport.WithPost<ObjectReference<O>> options() {
+        return new ExecuteOptionsBuilder.WithPost<ObjectReference<O>>() {
+            @Override
+            public TaskFuture<ObjectReference<O>> apost() throws CommonException {
+                setOptions(this.optionsAsStringList());
+                return RestPrismObjectModifyService.this.apost();
+            }
+        };
+    }
+
+    public RestPrismObjectModifyService(RestPrismService service, ObjectTypes type, String oid) {
+        this.service = service;
+        this.type = type;
+        this.oid = oid;
+        this.modifications = new ArrayList<>();
+    }
+
+    public RestPrismObjectModifyService<O> setOptions(List<String> options) {
+        this.options = options;
+        return this;
+    }
+
+    @Override
+    public RestPrismObjectModifyService<O> add(String path, Object value){
+        addModification(path, value, ModificationTypeType.ADD);
+        return this;
+    }
+
+    @Override
+    public RestPrismObjectModifyService<O> add(Map<String, Object> modifications){
+        addModifications(modifications, ModificationTypeType.ADD);
+        return this;
+    }
+
+    @Override
+    public RestPrismObjectModifyService<O> replace(String path, Object value){
+        addModification(path, value, ModificationTypeType.REPLACE);
+        return this;
+    }
+
+    @Override
+    public RestPrismObjectModifyService<O> replace(Map<String, Object> modifications){
+        addModifications(modifications, ModificationTypeType.REPLACE);
+        return this;
+    }
+
+    @Override
+    public RestPrismObjectModifyService<O> delete(String path, Object value){
+        addModification(path, value, ModificationTypeType.DELETE);
+        return this;
+    }
+
+    @Override
+    public RestPrismObjectModifyService<O> delete(Map<String, Object> modifications){
+        addModifications(modifications, ModificationTypeType.DELETE);
+        return this;
+    }
+
+    @Override
+    public RestPrismObjectModifyService<O> setModifications(InputStream inputStream) throws SchemaException {
+        this.modifications.addAll(((ObjectModificationType) service.parseObjectModification(inputStream)).getItemDelta());
+        return this;
+    }
+
+    private void addModification(String path, Object value, ModificationTypeType modificationType){
+        modifications.add(RestPrismUtils.buildItemDelta(modificationType, path, value));
+    }
+
+    private void addModifications(Map<String, Object> modifications, ModificationTypeType modificationType){
+        modifications.forEach((path, value) ->
+        addModification(path, value, modificationType));
+    }
+
+    @Override
+    public TaskFuture<ObjectReference<O>> apost() throws SchemaException, ObjectAlreadyExistsException, ObjectNotFoundException {
+
+        String oidRes = service.modifyObject(type, RestPrismUtils.buildModifyObject(modifications), options, oid);
+
+        RestPrismObjectReference<O> ref = new RestPrismObjectReference<>(oidRes, type.getClassDefinition());
+        return new RestPrismCompletedFuture<>(ref);
+    }
+
+}

--- a/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismObjectModifyService.java
+++ b/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismObjectModifyService.java
@@ -34,13 +34,10 @@ import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
 /**
  * @author Z14tk0
  */
-public class RestPrismObjectModifyService<O extends ObjectType> implements ObjectModifyService<O> {
+public class RestPrismObjectModifyService<O extends ObjectType> extends AbstractObjectWebResource<O> implements ObjectModifyService<O> {
 
     private List<ItemDeltaType> modifications;
-    private final RestPrismService service;
-    private final ObjectTypes type;
     private List<String> options;
-    private String oid;
 
     @Override
     public ExecuteOptionSupport.WithPost<ObjectReference<O>> options() {
@@ -54,9 +51,7 @@ public class RestPrismObjectModifyService<O extends ObjectType> implements Objec
     }
 
     public RestPrismObjectModifyService(RestPrismService service, ObjectTypes type, String oid) {
-        this.service = service;
-        this.type = type;
-        this.oid = oid;
+        super(service, type.getClassDefinition(), oid);
         this.modifications = new ArrayList<>();
     }
 
@@ -103,7 +98,7 @@ public class RestPrismObjectModifyService<O extends ObjectType> implements Objec
 
     @Override
     public RestPrismObjectModifyService<O> setModifications(InputStream inputStream) throws SchemaException {
-        this.modifications.addAll(((ObjectModificationType) service.parseObjectModification(inputStream)).getItemDelta());
+        this.modifications.addAll(((ObjectModificationType) ((RestPrismService) getService()).parseObjectModification(inputStream)).getItemDelta());
         return this;
     }
 
@@ -119,9 +114,9 @@ public class RestPrismObjectModifyService<O extends ObjectType> implements Objec
     @Override
     public TaskFuture<ObjectReference<O>> apost() throws SchemaException, ObjectAlreadyExistsException, ObjectNotFoundException {
 
-        String oidRes = service.modifyObject(type, RestPrismUtils.buildModifyObject(modifications), options, oid);
+        String oidRes = ((RestPrismService) getService()).modifyObject(ObjectTypes.getObjectType(getType()), RestPrismUtils.buildModifyObject(modifications), options, getOid());
 
-        RestPrismObjectReference<O> ref = new RestPrismObjectReference<>(oidRes, type.getClassDefinition());
+        RestPrismObjectReference<O> ref = new RestPrismObjectReference<>((RestPrismService) getService(), oidRes, getType());
         return new RestPrismCompletedFuture<>(ref);
     }
 

--- a/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismObjectReference.java
+++ b/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismObjectReference.java
@@ -15,16 +15,27 @@
  */
 package com.evolveum.midpoint.client.impl.prism;
 
+import com.evolveum.midpoint.client.api.AbstractObjectWebResource;
 import com.evolveum.midpoint.client.api.ObjectReference;
 import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.client.api.exception.SchemaException;
+import com.evolveum.midpoint.schema.constants.ObjectTypes;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
 
-public class RestPrismObjectReference<O extends ObjectType> implements ObjectReference<O> {
+public class RestPrismObjectReference<O extends ObjectType> extends AbstractObjectWebResource<O> implements ObjectReference<O> {
 
     private String oid;
     private Class<O> type;
+    private O object = null;
 
-    public RestPrismObjectReference(String oid, Class type) {
+    public RestPrismObjectReference(String oid, Class<O> type) {
+        super(null, type, oid);
+        this.oid = oid;
+        this.type = type;
+    }
+
+    public RestPrismObjectReference(RestPrismService service, String oid, Class<O> type) {
+        super(service, type, oid);
         this.oid = oid;
         this.type = type;
     }
@@ -41,7 +52,7 @@ public class RestPrismObjectReference<O extends ObjectType> implements ObjectRef
 
     @Override
     public O getObject() throws ObjectNotFoundException {
-        return null;
+        return object;
     }
 
     @Override
@@ -50,7 +61,10 @@ public class RestPrismObjectReference<O extends ObjectType> implements ObjectRef
     }
 
     @Override
-    public O get() throws ObjectNotFoundException {
-        return null;
+    public O get() throws ObjectNotFoundException, SchemaException {
+        if (object == null) {
+            object = ((RestPrismService) getService()).getObject(ObjectTypes.getObjectType(getType()), getOid());
+        }
+        return object;
     }
 }

--- a/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismObjectService.java
+++ b/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismObjectService.java
@@ -52,7 +52,7 @@ public class RestPrismObjectService<O extends ObjectType> extends CommonPrismSer
 
     @Override
     public ObjectModifyService<O> modify() throws ObjectNotFoundException, AuthenticationException {
-        throw new UnsupportedOperationException("Not impelemted yet");
+        return new RestPrismObjectModifyService<>(getService(), getType(), getOid());
     }
 
     @Override

--- a/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismUtils.java
+++ b/midpoint-client-impl-prism/src/main/java/com/evolveum/midpoint/client/impl/prism/RestPrismUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017-2025 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.evolveum.midpoint.client.impl.prism;
+
+import java.util.List;
+
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectModificationType;
+import com.evolveum.prism.xml.ns._public.types_3.ItemDeltaType;
+import com.evolveum.prism.xml.ns._public.types_3.ItemPathType;
+import com.evolveum.prism.xml.ns._public.types_3.ModificationTypeType;
+import com.evolveum.prism.xml.ns._public.types_3.RawType;
+
+/**
+ * @author Z14tk0
+ */
+public final class RestPrismUtils {
+
+    private RestPrismUtils() {
+        throw new UnsupportedOperationException("Class cannot be instantiated.");
+    }
+
+    public static ObjectModificationType buildModifyObject(List<ItemDeltaType> itemDeltas) {
+        ObjectModificationType objectModificationType = new ObjectModificationType();
+        itemDeltas.forEach(itemDelta -> objectModificationType.getItemDelta().add(itemDelta));
+
+        return objectModificationType;
+    }
+
+    public static ItemDeltaType buildItemDelta(ModificationTypeType modificationType, String path, Object value) {
+        //Create ItemDelta
+        ItemDeltaType itemDeltaType = new ItemDeltaType();
+        itemDeltaType.setModificationType(modificationType);
+
+        //Set Path
+        ItemPathType itemPathType = new ItemPathType(ItemPath.fromString(path));
+        itemDeltaType.setPath(itemPathType);
+
+        if (value != null) {
+            itemDeltaType.getValue().add(RawType.fromPropertyRealValue(value, null));   //TODO recheck if this works in all cases?
+        }
+
+        return itemDeltaType;
+    }
+}

--- a/midpoint-client-impl-prism/src/test/java/com/evolveum/midpoint/client/impl/prism/TestRestPrismService.java
+++ b/midpoint-client-impl-prism/src/test/java/com/evolveum/midpoint/client/impl/prism/TestRestPrismService.java
@@ -15,7 +15,9 @@
  */
 package com.evolveum.midpoint.client.impl.prism;
 
-import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -27,19 +29,32 @@ import com.evolveum.midpoint.client.api.ObjectReference;
 import com.evolveum.midpoint.client.api.Service;
 import com.evolveum.midpoint.client.api.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
 
 public class TestRestPrismService {
 
+    private static final String DATA_DIR = "src/test/resources/request";
 
     private Service service;
+    private String testUserOid;
+
 
     @BeforeClass
     public void init() throws Exception {
         service = createClient();
+
+        //Create a user to later use in tests, optionally set other fields...
+        UserType testUser = new UserType();
+        testUser.setName(new PolyStringType("testUser"));
+        ObjectReference<UserType> ref = service.users().add(testUser).post();
+        Assert.assertNotNull(ref.getOid(), "User OID must not be null after creation.");
+        testUserOid = ref.getOid();
     }
 
     @AfterClass
-    public void shutdown() {
+    public void shutdown() throws ObjectNotFoundException {
+        service.users().oid(testUserOid).delete();
         service.close();
     }
 
@@ -51,7 +66,6 @@ public class TestRestPrismService {
         System.out.println("User : " + user.getName());
 
         AssertJUnit.assertEquals("administrator", user.getName().getOrig());
-
     }
 
     @Test
@@ -100,6 +114,29 @@ public class TestRestPrismService {
         }
 
     }
+
+    /**
+     * Calls the modify service using setModifications(InputStream)
+     * and verifies that the returned OID matches the test user’s OID. (HTTP PATCH)
+     * Org in filter can be found here in overlay example project https://github.com/Evolveum/midpoint-overlay-example/blob/master/src/main/resources/initial-objects/920-org-root.xml
+     */
+    @Test
+    public void test030ModifyUser() throws Exception {
+        File file = new File(DATA_DIR, "user-patch-delta.json");
+
+        try (InputStream inputStream = new FileInputStream(file)) {
+            // Call the modify service using setModifications(inputStream) and then post the changes.
+            ObjectReference<UserType> userRef = service.users().oid(testUserOid)
+                    .modify()
+                    .setModifications(inputStream)
+                    .post();
+
+            AssertJUnit.assertNotNull(userRef.getOid());
+            Assert.assertEquals(userRef.getOid(), testUserOid, "Modified OID should match the test user's OID.");
+        }
+    }
+
+
 
     @Test
     public void test100testResource() throws Exception {

--- a/midpoint-client-impl-prism/src/test/resources/request/user-patch-delta.json
+++ b/midpoint-client-impl-prism/src/test/resources/request/user-patch-delta.json
@@ -1,0 +1,18 @@
+{
+    "objectModification": {
+        "itemDelta": [
+            {
+                "modificationType": "add",
+                "path": "assignment",
+                "value": [
+                    {
+                        "targetRef": {
+                            "filter": { "text": ". inOid (\"258cfacc-4705-11e8-b772-874c20402410\")" },
+                            "type": "c:OrgType"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
+++ b/midpoint-client-impl-rest-jaxb/src/main/java/com/evolveum/midpoint/client/impl/restjaxb/RestJaxbObjectModifyService.java
@@ -16,7 +16,7 @@
 package com.evolveum.midpoint.client.impl.restjaxb;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -24,7 +24,6 @@ import com.evolveum.midpoint.client.api.*;
 
 import com.evolveum.midpoint.client.api.exception.*;
 
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
@@ -86,6 +85,11 @@ public class RestJaxbObjectModifyService<O extends ObjectType> extends AbstractO
     public RestJaxbObjectModifyService<O> delete(Map<String, Object> modifications){
         addModifications(modifications, ModificationTypeType.DELETE);
         return this;
+    }
+
+    @Override
+    public RestJaxbObjectModifyService<O> setModifications(InputStream inputStream) throws SchemaException {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     private void addModification(String path, Object value, ModificationTypeType modificationType){


### PR DESCRIPTION
This PR enables HTTP PATCH requests in the clients Prism implementation module. It is the first of several PRs aimed at implementing the rest of the Prism module functionality.

The goal is to support a fluent API usage such as (see TestRestPrismService.java for a usage example):

midpointClient.users().oid(oid).modify()**.setModifications(inputStream)**.post(); 

Please let me know if any additional changes are needed or if you have feedback on the code structure.

Best regards, thank you
Z14tk0